### PR TITLE
#112 Removed log4j dependency and switched it for slf4j.  (Logback used ...

### DIFF
--- a/java/code/pom.xml
+++ b/java/code/pom.xml
@@ -250,11 +250,11 @@
     	<scope>compile</scope>
     </dependency>
     <dependency>
-    	<groupId>log4j</groupId>
-    	<artifactId>log4j</artifactId>
-    	<version>1.2.14</version>
-    	<type>jar</type>
-    	<scope>compile</scope>
+         <groupId>org.slf4j</groupId>
+         <artifactId>slf4j-api</artifactId>
+         <version>1.7.6</version>
+         <type>jar</type>
+         <scope>compile</scope>
     </dependency>
 
     <!-- Dependencies required for testing -->
@@ -282,6 +282,14 @@
         <version>3.3</version>
         <scope>test</scope>
     </dependency>
+    <dependency> <!-- Logback is only used for tests. -->
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>1.1.1</version>
+        <type>jar</type>
+        <scope>test</scope>
+    </dependency>
+    
   </dependencies>
 
   <!-- Perhaps we can't do this with git?

--- a/java/code/src/org/keyczar/Crypter.java
+++ b/java/code/src/org/keyczar/Crypter.java
@@ -16,7 +16,8 @@
 
 package org.keyczar;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.keyczar.enums.KeyPurpose;
 import org.keyczar.exceptions.BadVersionException;
 import org.keyczar.exceptions.InvalidSignatureException;
@@ -40,7 +41,7 @@ import java.nio.ByteBuffer;
  */
 public class Crypter extends Encrypter {
   private static final int DECRYPT_CHUNK_SIZE = 1024;
-  private static final Logger LOG = Logger.getLogger(Crypter.class);
+  private static final Logger LOG = LoggerFactory.getLogger(Crypter.class);
   private final StreamCache<DecryptingStream> CRYPT_CACHE
     = new StreamCache<DecryptingStream>();
 

--- a/java/code/src/org/keyczar/Encrypter.java
+++ b/java/code/src/org/keyczar/Encrypter.java
@@ -16,7 +16,8 @@
 
 package org.keyczar;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.keyczar.enums.KeyPurpose;
 import org.keyczar.exceptions.KeyczarException;
 import org.keyczar.exceptions.NoPrimaryKeyException;
@@ -42,7 +43,7 @@ import java.nio.ByteBuffer;
  */
 public class Encrypter extends Keyczar {
   private static final Logger LOG =
-    Logger.getLogger(Encrypter.class);
+    LoggerFactory.getLogger(Encrypter.class);
   private static final int ENCRYPT_CHUNK_SIZE = 1024;
   private final StreamQueue<EncryptingStream> ENCRYPT_QUEUE =
     new StreamQueue<EncryptingStream>();
@@ -75,7 +76,7 @@ public class Encrypter extends Keyczar {
   public Encrypter(String fileLocation) throws KeyczarException {
     super(fileLocation);
   }
-  
+
   /**
    * Returns the size of the ciphertext output that would result from encrypting
    * an input of the given length.

--- a/java/code/src/org/keyczar/GenericKeyczar.java
+++ b/java/code/src/org/keyczar/GenericKeyczar.java
@@ -1,6 +1,7 @@
 package org.keyczar;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.keyczar.enums.KeyPurpose;
 import org.keyczar.enums.KeyStatus;
 import org.keyczar.exceptions.KeyczarException;
@@ -25,7 +26,7 @@ import java.util.Set;
  *
  */
 class GenericKeyczar extends Keyczar {
-  private static final Logger LOG = Logger.getLogger(GenericKeyczar.class);
+  private static final Logger LOG = LoggerFactory.getLogger(GenericKeyczar.class);
   GenericKeyczar(KeyczarReader reader) throws KeyczarException {
     super(reader);
   }

--- a/java/code/src/org/keyczar/Keyczar.java
+++ b/java/code/src/org/keyczar/Keyczar.java
@@ -16,7 +16,8 @@
 
 package org.keyczar;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.keyczar.enums.KeyPurpose;
 import org.keyczar.enums.KeyStatus;
 import org.keyczar.exceptions.KeyczarException;
@@ -35,7 +36,7 @@ import java.util.HashMap;
  *
  */
 abstract class Keyczar {
-  private static final Logger LOG = Logger.getLogger(Keyczar.class);
+  private static final Logger LOG = LoggerFactory.getLogger(Keyczar.class);
   static final String DEFAULT_ENCODING = "UTF-8";
   static final byte FORMAT_VERSION = 0;
   static final byte[] FORMAT_BYTES = { FORMAT_VERSION };

--- a/java/code/src/org/keyczar/Signer.java
+++ b/java/code/src/org/keyczar/Signer.java
@@ -16,7 +16,8 @@
 
 package org.keyczar;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.keyczar.enums.KeyPurpose;
 import org.keyczar.exceptions.KeyczarException;
 import org.keyczar.exceptions.NoPrimaryKeyException;
@@ -42,7 +43,7 @@ import java.nio.ByteBuffer;
  */
 public class Signer extends Verifier {
   static final int TIMESTAMP_SIZE = 8;
-  private static final Logger LOG = Logger.getLogger(Signer.class);
+  private static final Logger LOG = LoggerFactory.getLogger(Signer.class);
   private final StreamQueue<SigningStream> SIGN_QUEUE = new StreamQueue<SigningStream>();
 
   /**

--- a/java/code/src/org/keyczar/UnversionedSigner.java
+++ b/java/code/src/org/keyczar/UnversionedSigner.java
@@ -16,7 +16,8 @@
 
 package org.keyczar;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.keyczar.enums.KeyPurpose;
 import org.keyczar.exceptions.KeyczarException;
 import org.keyczar.exceptions.NoPrimaryKeyException;
@@ -33,7 +34,7 @@ import java.nio.ByteBuffer;
  * UnversionedSigners may both sign and verify data using sets of symmetric or
  * private keys. Sets of public keys may only be used with {@link Verifier}
  * objects.
- * 
+ *
  * UnversionedSigners do not include any key versioning in their outputs. They
  * will return standard signatures (i.e. HMAC-SHA1, RSA-SHA1, DSA-SHA1).
  *
@@ -45,7 +46,7 @@ import java.nio.ByteBuffer;
  */
 public class UnversionedSigner extends UnversionedVerifier {
   static final int TIMESTAMP_SIZE = 8;
-  private static final Logger LOG = Logger.getLogger(UnversionedSigner.class);
+  private static final Logger LOG = LoggerFactory.getLogger(UnversionedSigner.class);
   private final StreamQueue<SigningStream> SIGN_QUEUE =
     new StreamQueue<SigningStream>();
 

--- a/java/code/src/org/keyczar/UnversionedVerifier.java
+++ b/java/code/src/org/keyczar/UnversionedVerifier.java
@@ -16,7 +16,8 @@
 
 package org.keyczar;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.keyczar.enums.KeyPurpose;
 import org.keyczar.exceptions.KeyczarException;
 import org.keyczar.i18n.Messages;
@@ -44,7 +45,7 @@ import java.nio.ByteBuffer;
 */
 public class UnversionedVerifier extends Keyczar {
   private static final Logger LOG =
-    Logger.getLogger(UnversionedVerifier.class);
+    LoggerFactory.getLogger(UnversionedVerifier.class);
   private static final StreamCache<VerifyingStream> VERIFY_CACHE
     = new StreamCache<VerifyingStream>();
 

--- a/java/code/src/org/keyczar/interop/Interop.java
+++ b/java/code/src/org/keyczar/interop/Interop.java
@@ -4,8 +4,6 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
-import org.apache.log4j.BasicConfigurator;
-import org.apache.log4j.varia.NullAppender;
 import org.keyczar.exceptions.KeyczarException;
 
 /**
@@ -18,7 +16,7 @@ public class Interop {
    * @param args
    */
   public static void main(String[] args) {
-    BasicConfigurator.configure(new NullAppender());
+
     Gson gson = new Gson();
     switch (getCommandType(args[0])) {
       case GENERATE:
@@ -53,7 +51,7 @@ public class Interop {
         System.exit(1);
     }
   }
-  
+
   /**
    * Parses the json input and returns the command attribute as an enum
    * @param jsonString
@@ -64,7 +62,7 @@ public class Interop {
     JsonObject object = parser.parse(jsonString).getAsJsonObject();
     return InteropCommand.getCommand(object.get("command").getAsString());
   }
-  
-  
+
+
 
 }

--- a/java/code/testdata/logback-test.xml
+++ b/java/code/testdata/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration scan="true">
+	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder>
+          <pattern>%-4r [%t] %-5p %c %x - %m%n</pattern>
+		</encoder>	
+	</appender>
+    	
+	<logger name="org.keyczar" level="INFO" />
+       
+	<root level="INFO">
+		<appender-ref ref="CONSOLE" />
+	</root>
+  
+  
+</configuration>

--- a/java/code/tests/log4j.properties
+++ b/java/code/tests/log4j.properties
@@ -1,9 +1,0 @@
-# Set root logger level to INFO and its only appender to A1.
-log4j.rootLogger=INFO, A1
-
-# A1 is set to be a ConsoleAppender.
-log4j.appender.A1=org.apache.log4j.ConsoleAppender
-
-# A1 uses PatternLayout.
-log4j.appender.A1.layout=org.apache.log4j.PatternLayout
-log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n

--- a/java/code/tests/org/keyczar/CrypterTest.java
+++ b/java/code/tests/org/keyczar/CrypterTest.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,7 +22,8 @@ import java.util.Arrays;
 
 import junit.framework.TestCase;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.junit.Test;
 import org.keyczar.exceptions.KeyNotFoundException;
 import org.keyczar.exceptions.KeyczarException;
@@ -30,17 +31,17 @@ import org.keyczar.exceptions.ShortCiphertextException;
 import org.keyczar.interfaces.KeyczarReader;
 
 /**
- * Tests Crypter class for encrypting and decrypting with RSA and AES. 
+ * Tests Crypter class for encrypting and decrypting with RSA and AES.
  *
  * @author steveweis@gmail.com (Steve Weis)
  *
  */
 
 public class CrypterTest extends TestCase {
-  private static final Logger LOG = Logger.getLogger(CrypterTest.class);
+  private static final Logger LOG = LoggerFactory.getLogger(CrypterTest.class);
   private static final String TEST_DATA = "./testdata";
   private String input = "This is some test data";
-  
+
   private final void testDecrypt(String subDir) throws Exception {
     testDecrypt(new KeyczarFileReader(TEST_DATA + subDir), subDir);
   }
@@ -50,7 +51,7 @@ public class CrypterTest extends TestCase {
     Crypter crypter = new Crypter(reader);
     RandomAccessFile activeInput =
       new RandomAccessFile(TEST_DATA + subDir + "/1.out", "r");
-    String activeCiphertext = activeInput.readLine(); 
+    String activeCiphertext = activeInput.readLine();
     activeInput.close();
     RandomAccessFile primaryInput =
       new RandomAccessFile(TEST_DATA + subDir + "/2.out", "r");
@@ -61,13 +62,13 @@ public class CrypterTest extends TestCase {
     String primaryDecrypted = crypter.decrypt(primaryCiphertext);
     assertEquals(input, primaryDecrypted);
   }
-  
+
   @Test
   public final void testAesDecrypt() throws Exception {
     testDecrypt("/aes");
   }
-  
-  @Test 
+
+  @Test
   public final void testAesEncryptedKeyDecrypt() throws Exception {
     // Test reading and using encrypted keys
     KeyczarFileReader fileReader =
@@ -77,12 +78,12 @@ public class CrypterTest extends TestCase {
       new KeyczarEncryptedReader(fileReader, keyDecrypter);
     testDecrypt(reader, "/aes-crypted");
   }
-  
+
   @Test
   public final void testRsaDecrypt() throws Exception  {
     testDecrypt("/rsa");
   }
-  
+
   @Test
   public final void testAesEncryptAndDecrypt() throws KeyczarException {
     Crypter crypter = new Crypter(TEST_DATA + "/aes");
@@ -100,7 +101,7 @@ public class CrypterTest extends TestCase {
     String decrypted = crypter.decrypt(ciphertext);
     assertEquals(input, decrypted);
   }
-  
+
   @Test
   public final void testRsaEncryptAndDecryptWithEncrypter() throws KeyczarException {
     Encrypter encrypter = new Encrypter(TEST_DATA + "/rsa.public");
@@ -139,6 +140,6 @@ public class CrypterTest extends TestCase {
       crypter.decrypt(ciphertext);  // discard garbage decrypted output
     } catch (KeyNotFoundException e) {
       // Expected exception
-    }    
+    }
   }
 }

--- a/java/code/tests/org/keyczar/SessionTest.java
+++ b/java/code/tests/org/keyczar/SessionTest.java
@@ -18,7 +18,8 @@ package org.keyczar;
 
 import junit.framework.TestCase;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.junit.Test;
 import org.keyczar.exceptions.KeyczarException;
 import org.keyczar.util.Base64Coder;
@@ -35,7 +36,7 @@ import java.util.Arrays;
  */
 @SuppressWarnings("deprecation")
 public class SessionTest extends TestCase {
-  private static final Logger LOG = Logger.getLogger(SessionTest.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SessionTest.class);
   private static final String TEST_DATA = "./testdata";
   private String input = "This is some test data";
   // Bigger than a public key block

--- a/java/code/tests/org/keyczar/SignedSessionTest.java
+++ b/java/code/tests/org/keyczar/SignedSessionTest.java
@@ -22,7 +22,8 @@ import java.util.Arrays;
 
 import junit.framework.TestCase;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.junit.Test;
 import org.keyczar.annotations.Experimental;
 import org.keyczar.exceptions.KeyczarException;
@@ -36,7 +37,7 @@ import org.keyczar.util.Base64Coder;
  */
 @Experimental
 public class SignedSessionTest extends TestCase {
-  private static final Logger LOG = Logger.getLogger(SignedSessionTest.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SignedSessionTest.class);
   private static final String TEST_DATA = "./testdata";
   private String input = "This is some test data";
   // Bigger than a public key block

--- a/java/code/tests/org/keyczar/SignerTest.java
+++ b/java/code/tests/org/keyczar/SignerTest.java
@@ -4,9 +4,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,7 +22,8 @@ import java.nio.ByteBuffer;
 
 import junit.framework.TestCase;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.junit.Test;
 import org.keyczar.exceptions.BadVersionException;
 import org.keyczar.exceptions.KeyNotFoundException;
@@ -36,7 +37,7 @@ import org.keyczar.exceptions.ShortSignatureException;
  *
  */
 public class SignerTest extends TestCase {
-  private static final Logger LOG = Logger.getLogger(SignerTest.class);
+  private static final Logger LOG = LoggerFactory.getLogger(SignerTest.class);
   private static final String TEST_DATA = "./testdata";
   private String input = "This is some test data";
   private byte[] inputBytes = input.getBytes();
@@ -45,7 +46,7 @@ public class SignerTest extends TestCase {
     Signer signer = new Signer(TEST_DATA + subDir);
     RandomAccessFile activeInput =
       new RandomAccessFile(TEST_DATA + subDir + "/1.out", "r");
-    String activeSignature = activeInput.readLine(); 
+    String activeSignature = activeInput.readLine();
     activeInput.close();
     RandomAccessFile primaryInput =
       new RandomAccessFile(TEST_DATA + subDir + "/2.out", "r");
@@ -55,13 +56,13 @@ public class SignerTest extends TestCase {
     assertTrue(signer.verify(input, activeSignature));
     assertTrue(signer.verify(input, primarySignature));
   }
-  
+
   private final void testPublicVerify(String subDir) throws Exception {
     Verifier verifier = new Verifier(TEST_DATA + subDir);
     Verifier publicVerifier = new Verifier(TEST_DATA + subDir + ".public");
     RandomAccessFile activeInput =
       new RandomAccessFile(TEST_DATA + subDir + "/1.out", "r");
-    String activeSignature = activeInput.readLine(); 
+    String activeSignature = activeInput.readLine();
     activeInput.close();
     RandomAccessFile primaryInput =
       new RandomAccessFile(TEST_DATA + subDir + "/2.out", "r");
@@ -78,7 +79,7 @@ public class SignerTest extends TestCase {
     Signer signer = new Signer(TEST_DATA + subDir);
     RandomAccessFile activeInput =
       new RandomAccessFile(TEST_DATA + subDir + "/1.out", "r");
-    String activeSignature = activeInput.readLine(); 
+    String activeSignature = activeInput.readLine();
     activeInput.close();
     RandomAccessFile primaryInput =
       new RandomAccessFile(TEST_DATA + subDir + "/2.out", "r");
@@ -91,7 +92,7 @@ public class SignerTest extends TestCase {
     assertFalse(signer.verify(input,
         primarySignature.substring(0, primarySignature.length() - 4) + "Junk"));
   }
-  
+
   @Test
   public final void testHmacSignAndVerify() throws KeyczarException {
     Signer hmacSigner = new Signer(TEST_DATA + "/hmac");
@@ -115,12 +116,12 @@ public class SignerTest extends TestCase {
   public final void testHmacVerify() throws Exception {
     testSignerVerify("/hmac");
   }
-  
+
   @Test
   public final void testBadHmacVerify() throws Exception {
     testBadVerify("/hmac");
   }
-  
+
   @Test
   public final void testDsaSignAndVerify() throws KeyczarException {
     Signer dsaSigner = new Signer(TEST_DATA + "/dsa");
@@ -135,12 +136,12 @@ public class SignerTest extends TestCase {
     testSignerVerify("/dsa");
     testPublicVerify("/dsa");
   }
-  
+
   @Test
   public final void testBadDsaVerify() throws Exception {
     testBadVerify("/dsa");
   }
-    
+
   @Test
   public final void testRsaSignAndVerify() throws KeyczarException {
     Signer rsaSigner = new Signer(TEST_DATA + "/rsa-sign");
@@ -160,19 +161,19 @@ public class SignerTest extends TestCase {
   public final void testBadRsaVerify() throws Exception {
     testBadVerify("/rsa-sign");
   }
-  
+
   private final void testUnversionedSignAndVerify(String subDir)
       throws Exception {
     UnversionedSigner signer = new UnversionedSigner(TEST_DATA + subDir);
     byte[] sig = signer.sign(inputBytes);
     assertTrue(signer.verify(inputBytes, sig));
   }
-  
+
   @Test
   public final void testHmacUnversionedSignAndVerify() throws Exception {
     testUnversionedSignAndVerify("/hmac");
   }
-  
+
   @Test
   public final void testDsaUnversionedSignAndVerify() throws Exception {
     testUnversionedSignAndVerify("/dsa");
@@ -182,7 +183,7 @@ public class SignerTest extends TestCase {
   public final void testRsaUnversionedSignAndVerify() throws Exception {
     testUnversionedSignAndVerify("/rsa-sign");
   }
-  
+
   @Test
   public final void testHmacBadSigs() throws KeyczarException {
     Signer hmacSigner = new Signer(TEST_DATA + "/hmac");
@@ -214,6 +215,6 @@ public class SignerTest extends TestCase {
     }
     // Reset the key identifier
     sig[1] ^= 45;
-     
+
   }
 }


### PR DESCRIPTION
...for unit tests)

I believe that the call to log4j BasicConfigurer.configure() was just there to prevent error messages from happening, and that should not occur with slf4j so I think that should be ok.
