### PR TITLE
Modify build system to use user-specified gtest.

### DIFF
--- a/cpp/README
+++ b/cpp/README
@@ -1,16 +1,17 @@
 = Keyczar C++ =
 
-== Dependancies ==
+== Dependencies ==
 
 - C++ compiler
 - Python for running the build system
 - OpenSSL (>= 0.9.8b)
+- gtest (>= 1.4)
 - [Optional]: Zlib (for compression)
 - [Optional]: Swig (Python binding)
 
 === Ubuntu/Debian ===
 
-Packages g++ make libssl-dev zlib1g-dev python python-dev swig
+Packages g++ make libssl-dev zlib1g-dev libgtest-dev python python-dev swig
 
 === MacOSX Snow Leopard ===
 
@@ -22,6 +23,10 @@ you are using the C++ API, MacPorts is not necessary.
 Previous versions of Mac OS X should also work, but you should test to be
 sure.
 
+Download a copy of gtest from https://code.google.com/p/googletest/downloads
+and unpack it in a convenient location (you'll need the path for the build
+command below).
+
 == Supported architectures and systems ==
 
 Processors: x86, x86_64, ARM
@@ -32,10 +37,12 @@ Note: only Linux x86 has been tested extensively
 
 == Local build ==
 
-For a local build of Keyczar C++ on Linux run these commands:
+For a local build of Keyczar C++ on Linux (or, with small changes, on Mac) run these commands:
 
- $ cd src && sh ./tools/swtoolkit/hammer.sh --mode=opt-linux --compat
+ $ cd src && sh ./tools/swtoolkit/hammer.sh -D GTEST_DIR=/usr/src/gtest --mode=opt-linux --compat
 
+- Replace /usr/src/gtest with the path to your gtest src dir (this path is
+  correct for Ubuntu).
 - Replace opt-linux by opt-bsd or opt-mac depending on your system
 - The Python binding is built automatically if swig is detected
 - Libraries and executables are assembled under scons-out/opt-linux/
@@ -47,7 +54,7 @@ For a local build of Keyczar C++ on Linux run these commands:
 
 You need to log as root and execute these commands:
 
-  $ cd src && sh ./tools/swtoolkit/hammer.sh --mode=opt-linux --compat install
+  $ cd src && sh ./tools/swtoolkit/hammer.sh -D GTEST_DIR=/usr/src/gtest --mode=opt-linux --compat install
 
 /!\ Note: it is actually highly recommanded to use the compatibility (--compat)
 mode. This mode provides full compatibility with previous versions, other

--- a/cpp/src/keyczar/aes_key_unittest.cc
+++ b/cpp/src/keyczar/aes_key_unittest.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 #include <string>
 
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <keyczar/aes_key.h>
 #include <keyczar/base/base64w.h>

--- a/cpp/src/keyczar/base/base64w_unittest.cc
+++ b/cpp/src/keyczar/base/base64w_unittest.cc
@@ -16,8 +16,8 @@
 #include <keyczar/base/file_util.h>
 #include <keyczar/base_test/path_service.h>
 
-#include <testing/gtest/include/gtest/gtest.h>
-#include <testing/platform_test.h>
+#include <keyczar/platform_test.h>
+#include <gtest/gtest.h>
 
 namespace keyczar {
 namespace base {

--- a/cpp/src/keyczar/base/command_line_unittest.cc
+++ b/cpp/src/keyczar/base/command_line_unittest.cc
@@ -10,7 +10,7 @@
 #include <keyczar/base/logging.h>
 #include <keyczar/base/string_util.h>
 
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 namespace keyczar {
 namespace base {

--- a/cpp/src/keyczar/base/file_path_unittest.cc
+++ b/cpp/src/keyczar/base/file_path_unittest.cc
@@ -7,8 +7,8 @@
 #include <keyczar/base/file_util.h>
 #include <keyczar/base/string_util.h>
 
-#include <testing/gtest/include/gtest/gtest.h>
-#include <testing/platform_test.h>
+#include <keyczar/platform_test.h>
+#include <gtest/gtest.h>
 
 // This macro helps avoid wrapped lines in the test structs.
 #define FPL(x) FILE_PATH_LITERAL(x)

--- a/cpp/src/keyczar/base/file_util_posix.cc
+++ b/cpp/src/keyczar/base/file_util_posix.cc
@@ -57,7 +57,7 @@ FILE* OpenFile(const std::string& filename, const char* mode) {
 }
 
 int WriteFile(const std::string& filename, const char* data, int size) {
-  int fd = creat(filename.c_str(), 0666);
+  int fd = creat(filename.c_str(), 0600);
   if (fd < 0)
     return -1;
 
@@ -153,7 +153,7 @@ bool CreateDirectory(const FilePath& full_path) {
   for (std::vector<FilePath>::reverse_iterator i = subpaths.rbegin();
        i != subpaths.rend(); ++i) {
     if (!DirectoryExists(*i)) {
-      if (mkdir(i->value().c_str(), 0777) != 0)
+      if (mkdir(i->value().c_str(), 0700) != 0)
         return false;
     }
   }

--- a/cpp/src/keyczar/base/file_util_posix.cc
+++ b/cpp/src/keyczar/base/file_util_posix.cc
@@ -57,7 +57,7 @@ FILE* OpenFile(const std::string& filename, const char* mode) {
 }
 
 int WriteFile(const std::string& filename, const char* data, int size) {
-  int fd = creat(filename.c_str(), 0600);
+  int fd = creat(filename.c_str(), 0666);
   if (fd < 0)
     return -1;
 
@@ -153,7 +153,7 @@ bool CreateDirectory(const FilePath& full_path) {
   for (std::vector<FilePath>::reverse_iterator i = subpaths.rbegin();
        i != subpaths.rend(); ++i) {
     if (!DirectoryExists(*i)) {
-      if (mkdir(i->value().c_str(), 0700) != 0)
+      if (mkdir(i->value().c_str(), 0777) != 0)
         return false;
     }
   }

--- a/cpp/src/keyczar/base/file_util_unittest.cc
+++ b/cpp/src/keyczar/base/file_util_unittest.cc
@@ -21,8 +21,8 @@
 #include <keyczar/base_test/base_paths.h>
 #include <keyczar/base_test/path_service.h>
 
-#include <testing/gtest/include/gtest/gtest.h>
-#include <testing/platform_test.h>
+#include <keyczar/platform_test.h>
+#include <gtest/gtest.h>
 
 namespace keyczar {
 namespace base {

--- a/cpp/src/keyczar/base/json_reader_unittest.cc
+++ b/cpp/src/keyczar/base/json_reader_unittest.cc
@@ -6,7 +6,7 @@
 // with Keyczar, any encountered errors are probably due to these
 // modifications.
 
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <keyczar/base/build_config.h>
 #include <keyczar/base/json_reader.h>

--- a/cpp/src/keyczar/base/json_value_serializer_unittest.cc
+++ b/cpp/src/keyczar/base/json_value_serializer_unittest.cc
@@ -20,8 +20,8 @@
 #include <keyczar/base/values.h>
 #include <keyczar/base_test/path_service.h>
 
-#include <testing/gtest/include/gtest/gtest.h>
-#include <testing/platform_test.h>
+#include <keyczar/platform_test.h>
+#include <gtest/gtest.h>
 
 namespace keyczar {
 namespace base {

--- a/cpp/src/keyczar/base/json_writer_unittest.cc
+++ b/cpp/src/keyczar/base/json_writer_unittest.cc
@@ -6,7 +6,7 @@
 // with Keyczar, any encountered errors are probably due to these
 // modifications.
 
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <keyczar/base/json_writer.h>
 #include <keyczar/base/values.h>

--- a/cpp/src/keyczar/base/ref_counted_unittest.cc
+++ b/cpp/src/keyczar/base/ref_counted_unittest.cc
@@ -6,7 +6,7 @@
 // with Keyczar, any encountered errors are probably due to these
 // modifications.
 
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <keyczar/base/ref_counted.h>
 

--- a/cpp/src/keyczar/base/run_all_unittests.cc
+++ b/cpp/src/keyczar/base/run_all_unittests.cc
@@ -1,7 +1,7 @@
 // Copyright (c) 2006-2008 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);

--- a/cpp/src/keyczar/base/scoped_ptr_unittest.cc
+++ b/cpp/src/keyczar/base/scoped_ptr_unittest.cc
@@ -5,7 +5,7 @@
 #include <keyczar/base/basictypes.h>
 #include <keyczar/base/scoped_ptr.h>
 
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 namespace {
 

--- a/cpp/src/keyczar/base/string_escape_unittest.cc
+++ b/cpp/src/keyczar/base/string_escape_unittest.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <keyczar/base/string_escape.h>
 #include <keyczar/base/string_util.h>

--- a/cpp/src/keyczar/base/values_unittest.cc
+++ b/cpp/src/keyczar/base/values_unittest.cc
@@ -7,7 +7,7 @@
 #include <keyczar/base/values.h>
 #include <keyczar/base/scoped_ptr.h>
 
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 namespace keyczar {
 

--- a/cpp/src/keyczar/base/zlib_unittest.cc
+++ b/cpp/src/keyczar/base/zlib_unittest.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 #include <keyczar/base/zlib.h>
 
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 namespace keyczar {
 namespace base {

--- a/cpp/src/keyczar/build.scons
+++ b/cpp/src/keyczar/build.scons
@@ -14,7 +14,6 @@ if env.get('ZLIB_OPTION'):
             ],
         )
 
-
 #### Keyczar Library
 
 keyczar_lib_env = env.Clone()
@@ -253,6 +252,8 @@ if env.Bit('mac'):
 
 lib_unittests_env.Append(
     CPPPATH = [
+        ARGUMENTS['GTEST_DIR'],
+        ARGUMENTS['GTEST_DIR'] + '/include',
         ],
     LIBS = [
         lib_name,
@@ -262,6 +263,8 @@ lib_unittests_env.Append(
 unittests_sources = [
     'base_test/base_paths.cc',
     'base_test/path_service.cc',
+    'run_all_unittests.cc',
+    ARGUMENTS['GTEST_DIR'] + '/src/gtest-all.cc',
     ]
 
 unittests_posix_sources = [
@@ -277,6 +280,7 @@ unittests_bsd_sources = [
 
 unittests_mac_sources = [
     'base_test/base_paths_mac.mm',
+    'platform_test_mac.mm',
     ]
 
 unittests_win_sources = [
@@ -309,13 +313,11 @@ unittests_env = env.Clone()
 
 unittests_env.Append(
     CPPPATH = [
-        '../testing/gtest',
-        '../testing/gtest/include',
+        ARGUMENTS['GTEST_DIR'] + '/include',
         ],
     LIBS = [
         lib_name,
         unittest_lib_name,
-        'gtest',
         'crypto',
         ],
     )
@@ -329,7 +331,6 @@ base_unittests = [
     'base/json_value_serializer_unittest.cc',
     'base/json_writer_unittest.cc',
     'base/ref_counted_unittest.cc',
-    'base/run_all_unittests.cc',
     'base/scoped_ptr_unittest.cc',
     'base/string_escape_unittest.cc',
     'base/values_unittest.cc',
@@ -376,7 +377,6 @@ keyczar_unittests = [
     'keyset_metadata_unittest.cc',
     'keyset_unittest.cc',
     'rsa_key_unittest.cc',
-    'run_all_unittests.cc',
     'session_unittest.cc',
     ]
 

--- a/cpp/src/keyczar/dsa_key_unittest.cc
+++ b/cpp/src/keyczar/dsa_key_unittest.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 #include <string>
 
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <keyczar/base/base64w.h>
 #include <keyczar/base/logging.h>

--- a/cpp/src/keyczar/ecdsa_key_unittest.cc
+++ b/cpp/src/keyczar/ecdsa_key_unittest.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 #include <string>
 
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <keyczar/base/base64w.h>
 #include <keyczar/base/logging.h>

--- a/cpp/src/keyczar/hmac_key_unittest.cc
+++ b/cpp/src/keyczar/hmac_key_unittest.cc
@@ -14,7 +14,7 @@
 #include <string>
 #include <vector>
 
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <keyczar/base/base64w.h>
 #include <keyczar/base/logging.h>

--- a/cpp/src/keyczar/keyczar_test.h
+++ b/cpp/src/keyczar/keyczar_test.h
@@ -15,8 +15,8 @@
 #define KEYCZAR_KEYCZAR_TEST_H_
 #include <string>
 
-#include <testing/gtest/include/gtest/gtest.h>
-#include <testing/platform_test.h>
+#include <keyczar/platform_test.h>
+#include <gtest/gtest.h>
 
 #include <keyczar/base/file_path.h>
 #include <keyczar/base/file_util.h>

--- a/cpp/src/keyczar/keyczar_unittest.cc
+++ b/cpp/src/keyczar/keyczar_unittest.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 #include <string>
 
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <keyczar/base/file_path.h>
 #include <keyczar/base/file_util.h>

--- a/cpp/src/keyczar/keyset_metadata_unittest.cc
+++ b/cpp/src/keyczar/keyset_metadata_unittest.cc
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <keyczar/base/file_path.h>
 #include <keyczar/base/file_util.h>

--- a/cpp/src/keyczar/keyset_unittest.cc
+++ b/cpp/src/keyczar/keyset_unittest.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 #include <string>
 
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <keyczar/base/base64w.h>
 #include <keyczar/base/file_path.h>
@@ -233,4 +233,3 @@ TEST_F(KeysetTest, Observers) {
 }
 
 }  // namespace keyczar
-

--- a/cpp/src/keyczar/openssl/aes_unittest.cc
+++ b/cpp/src/keyczar/openssl/aes_unittest.cc
@@ -15,7 +15,7 @@
 
 #include <string>
 
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <keyczar/base/scoped_ptr.h>
 #include <keyczar/cipher_mode.h>

--- a/cpp/src/keyczar/openssl/dsa_unittest.cc
+++ b/cpp/src/keyczar/openssl/dsa_unittest.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 #include <string>
 
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <keyczar/base/file_path.h>
 #include <keyczar/base/file_util.h>

--- a/cpp/src/keyczar/openssl/ecdsa_unittest.cc
+++ b/cpp/src/keyczar/openssl/ecdsa_unittest.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 #include <string>
 
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <keyczar/base/file_path.h>
 #include <keyczar/base/file_util.h>

--- a/cpp/src/keyczar/openssl/hmac_unittest.cc
+++ b/cpp/src/keyczar/openssl/hmac_unittest.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 #include <string>
 
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <keyczar/base/base64w.h>
 #include <keyczar/openssl/hmac.h>

--- a/cpp/src/keyczar/openssl/message_digest_unittest.cc
+++ b/cpp/src/keyczar/openssl/message_digest_unittest.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 #include <string>
 
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <keyczar/base/base64w.h>
 #include <keyczar/openssl/message_digest.h>

--- a/cpp/src/keyczar/openssl/pbe_unittest.cc
+++ b/cpp/src/keyczar/openssl/pbe_unittest.cc
@@ -15,7 +15,7 @@
 
 #include <string>
 
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <keyczar/base/scoped_ptr.h>
 #include <keyczar/keyczar_test.h>

--- a/cpp/src/keyczar/openssl/rsa_unittest.cc
+++ b/cpp/src/keyczar/openssl/rsa_unittest.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 #include <string>
 
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <keyczar/base/file_path.h>
 #include <keyczar/base/file_util.h>

--- a/cpp/src/keyczar/platform_test.h
+++ b/cpp/src/keyczar/platform_test.h
@@ -1,0 +1,34 @@
+// Copyright (c) 2006-2008 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef TESTING_PLATFORM_TEST_H_
+#define TESTING_PLATFORM_TEST_H_
+
+#include <gtest/gtest.h>
+
+#if defined(GTEST_OS_MAC)
+#ifdef __OBJC__
+@class NSAutoreleasePool;
+#else
+class NSAutoreleasePool;
+#endif
+
+// The purpose of this class us to provide a hook for platform-specific
+// SetUp and TearDown across unit tests.  For example, on the Mac, it
+// creates and releases an outer AutoreleasePool for each test.  For now, it's
+// only implemented on the Mac.  To enable this for another platform, just
+// adjust the #ifdefs and add a platform_test_<platform>.cc implementation file.
+class PlatformTest : public testing::Test {
+ protected:
+  virtual void SetUp();
+  virtual void TearDown();
+
+ private:
+  NSAutoreleasePool* pool_;
+};
+#else
+typedef testing::Test PlatformTest;
+#endif // GTEST_OS_MAC
+
+#endif // TESTING_PLATFORM_TEST_H_

--- a/cpp/src/keyczar/platform_test_mac.mm
+++ b/cpp/src/keyczar/platform_test_mac.mm
@@ -1,0 +1,15 @@
+// Copyright (c) 2006-2008 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <keyczar/platform_test.h>
+
+#import <Foundation/Foundation.h>
+
+void PlatformTest::SetUp() {
+  pool_ = [[NSAutoreleasePool alloc] init];
+}
+
+void PlatformTest::TearDown() {
+  [pool_ drain];
+}

--- a/cpp/src/keyczar/rsa_key_unittest.cc
+++ b/cpp/src/keyczar/rsa_key_unittest.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 #include <string>
 
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <keyczar/base/base64w.h>
 #include <keyczar/base/logging.h>

--- a/cpp/src/keyczar/run_all_unittests.cc
+++ b/cpp/src/keyczar/run_all_unittests.cc
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <keyczar/crypto_factory.h>
 

--- a/cpp/src/keyczar/rw/keyset_reader_unittest.cc
+++ b/cpp/src/keyczar/rw/keyset_reader_unittest.cc
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 #include <keyczar/base/file_path.h>
 #include <keyczar/base/file_util.h>

--- a/cpp/src/keyczar/session_unittest.cc
+++ b/cpp/src/keyczar/session_unittest.cc
@@ -18,7 +18,7 @@
 #include <keyczar/base/base64w.h>
 #include <keyczar/keyczar_test.h>
 #include <keyczar/session.h>
-#include <testing/gtest/include/gtest/gtest.h>
+#include <gtest/gtest.h>
 
 namespace keyczar {
 

--- a/cpp/src/main.scons
+++ b/cpp/src/main.scons
@@ -82,7 +82,6 @@ if CheckHasWorkingSwig(conf):
 conf.CheckCXX()
 
 # Mandatory libraries
-# fixme: is pthread mandatory for unittests ?
 for lib in ('crypto','pthread'):
     # FIXME: currently these checks are not enforced some may not work
     # reliably on every supported architectures.

--- a/cpp/src/main.scons
+++ b/cpp/src/main.scons
@@ -19,7 +19,7 @@ base_env.Append(
     CPPPATH = ['$MAIN_DIR'],
 
     # The list of components common to all platforms.
-    BUILD_SCONSCRIPTS = ['testing', 'keyczar'],
+    BUILD_SCONSCRIPTS = ['keyczar'],
 
     # Sets architecture byte order
     CPPDEFINES = [
@@ -83,7 +83,7 @@ conf.CheckCXX()
 
 # Mandatory libraries
 # fixme: is pthread mandatory for unittests ?
-for lib in ('crypto',):
+for lib in ('crypto','pthread'):
     # FIXME: currently these checks are not enforced some may not work
     # reliably on every supported architectures.
     conf.CheckLib(lib)


### PR DESCRIPTION
The copy of gtest in the repository was old enough that it broke with
the new compiler on Ubuntu 14.04. Rather than try to keep the copy of
gtest up to date, change the build scripts to expect it to be installed
on the system at GTEST_DIR, a directory specified as a build command
line argument.

Also update the README to reflect this change.
