### PR TITLE
Make java version android-friendly

### DIFF
--- a/java/code/build.xml
+++ b/java/code/build.xml
@@ -14,8 +14,7 @@
         <pathelement location="${ECLIPSE_HOME}/plugins/org.junit4_4.3.1/junit.jar"/>
     </path>
     <path id="Maven Dependencies.libraryclasspath">
-        <pathelement location="../../.m2/repository/com/google/code/gson/gson/1.2/gson-1.2.jar"/>
-        <pathelement location="../../.m2/repository/log4j/log4j/1.2.14/log4j-1.2.14.jar"/>
+        <pathelement location="../../.m2/repository/org/json/json/20080701/json-20080701.jar"/>
         <pathelement location="../../.m2/repository/org/mozilla/jss/4/jss-4.jar"/>
         <pathelement location="../../.m2/repository/junit/junit/4.0/junit-4.0.jar"/>
         <pathelement location="../../.m2/repository/org/testng/testng/5.8/testng-5.8-jdk15.jar"/>

--- a/java/code/pom.xml
+++ b/java/code/pom.xml
@@ -243,26 +243,19 @@
 
     <!-- Dependencies required at runtime -->
     <dependency>
-    	<groupId>com.google.code.gson</groupId>
-    	<artifactId>gson</artifactId>
-    	<version>1.7.1</version>
-    	<type>jar</type>
-    	<scope>compile</scope>
-    </dependency>
-    <dependency>
-         <groupId>org.slf4j</groupId>
-         <artifactId>slf4j-api</artifactId>
-         <version>1.7.6</version>
-         <type>jar</type>
-         <scope>compile</scope>
+        <groupId>org.json</groupId>
+        <artifactId>json</artifactId>
+        <version>20080701</version>
+        <type>jar</type>
+        <scope>compile</scope>
     </dependency>
 
     <!-- Dependencies required for testing -->
     <dependency>
-    	<groupId>junit</groupId>
-    	<artifactId>junit</artifactId>
-    	<version>4.8.2</version>
-    	<scope>test</scope>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.8.2</version>
+        <scope>test</scope>
     </dependency>
     <dependency>
 	<groupId>org.easymock</groupId>

--- a/java/code/src/org/keyczar/AesKey.java
+++ b/java/code/src/org/keyczar/AesKey.java
@@ -16,8 +16,8 @@
 
 package org.keyczar;
 
-import com.google.gson.annotations.Expose;
-
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.keyczar.enums.CipherMode;
 import org.keyczar.exceptions.KeyczarException;
 import org.keyczar.exceptions.ShortBufferException;
@@ -55,9 +55,9 @@ public class AesKey extends KeyczarKey {
   private static final int NUM_OF_KEYS = 2; // AesKeys contain HMAC and AES keys
 
   private SecretKey aesKey;
-  @Expose private final String aesKeyString;
-  @Expose private final HmacKey hmacKey;
-  @Expose private final CipherMode mode;
+  private final String aesKeyString;
+  private final HmacKey hmacKey;
+  private final CipherMode mode;
 
   private final byte[] hash = new byte[Keyczar.KEY_HASH_SIZE];
 
@@ -73,12 +73,11 @@ public class AesKey extends KeyczarKey {
     initJceKey(aesKeyBytes);
   }
 
-  // Used by GSON, which will overwrite the values set here.
-  private AesKey() {
-    super(0);
-    aesKeyString = null;
-    hmacKey = null;
-    mode = null;
+  private AesKey(int size, String aesKeyString, HmacKey hmacKey, CipherMode mode) {
+    super(size);
+    this.aesKeyString = aesKeyString;
+    this.hmacKey = hmacKey;
+    this.mode = mode;
   }
 
   static AesKey generate(AesKeyParameters params) throws KeyczarException {
@@ -107,10 +106,36 @@ public class AesKey extends KeyczarKey {
   }
 
   static AesKey read(String input) throws KeyczarException {
-    AesKey key = Util.gson().fromJson(input, AesKey.class);
-    key.hmacKey.initFromJson();
-    key.initJceKey(Base64Coder.decodeWebSafe(key.aesKeyString));
+    try {
+      AesKey key = fromJson(new JSONObject(input));
+      key.hmacKey.initFromJson();
+      key.initJceKey(Base64Coder.decodeWebSafe(key.aesKeyString));
+      return key;
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  static AesKey fromJson(JSONObject json) throws JSONException {
+    AesKey key = new AesKey(
+        json.getInt("size"),
+        json.getString("aesKeyString"),
+        HmacKey.fromJson(json.getJSONObject("hmacKey")),
+        Util.deserializeEnum(CipherMode.class, json.getString("mode")));
     return key;
+  }
+
+  @Override
+  JSONObject toJson() {
+    try {
+      return new JSONObject()
+        .put("size", size)
+        .put("aesKeyString", aesKeyString)
+        .put("hmacKey", hmacKey != null ? hmacKey.toJson() : null)
+        .put("mode", mode.name());
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   private void initJceKey(byte[] aesBytes) throws KeyczarException {

--- a/java/code/src/org/keyczar/Crypter.java
+++ b/java/code/src/org/keyczar/Crypter.java
@@ -16,8 +16,6 @@
 
 package org.keyczar;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.keyczar.enums.KeyPurpose;
 import org.keyczar.exceptions.BadVersionException;
 import org.keyczar.exceptions.InvalidSignatureException;
@@ -41,7 +39,6 @@ import java.nio.ByteBuffer;
  */
 public class Crypter extends Encrypter {
   private static final int DECRYPT_CHUNK_SIZE = 1024;
-  private static final Logger LOG = LoggerFactory.getLogger(Crypter.class);
   private final StreamCache<DecryptingStream> CRYPT_CACHE
     = new StreamCache<DecryptingStream>();
 
@@ -102,7 +99,6 @@ public class Crypter extends Encrypter {
   public void decrypt(ByteBuffer input, ByteBuffer output)
       throws KeyczarException {
     ByteBuffer inputCopy = input.asReadOnlyBuffer();
-    LOG.debug(Messages.getString("Crypter.Decrypting", inputCopy.remaining()));
     if (inputCopy.remaining() < HEADER_SIZE) {
       throw new ShortCiphertextException(inputCopy.remaining());
     }

--- a/java/code/src/org/keyczar/DsaPrivateKey.java
+++ b/java/code/src/org/keyczar/DsaPrivateKey.java
@@ -16,8 +16,8 @@
 
 package org.keyczar;
 
-import com.google.gson.annotations.Expose;
-
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.keyczar.exceptions.KeyczarException;
 import org.keyczar.interfaces.KeyType;
 import org.keyczar.interfaces.SigningStream;
@@ -47,8 +47,8 @@ public class DsaPrivateKey extends KeyczarKey implements KeyczarPrivateKey {
   private static final String SIG_ALGORITHM = "SHA1withDSA";
   private static final int DSA_DIGEST_SIZE = 48;
 
-  @Expose private final DsaPublicKey publicKey;
-  @Expose private final String x;
+  private final DsaPublicKey publicKey;
+  private final String x;
 
   private DSAPrivateKey jcePrivateKey;
 
@@ -58,8 +58,28 @@ public class DsaPrivateKey extends KeyczarKey implements KeyczarPrivateKey {
   }
 
   static DsaPrivateKey read(String input) throws KeyczarException {
-    DsaPrivateKey key = Util.gson().fromJson(input, DsaPrivateKey.class);
-    return key.initFromJson();
+    try {
+      JSONObject json = new JSONObject(input);
+      DsaPrivateKey key = new DsaPrivateKey(
+          json.getInt("size"),
+          DsaPublicKey.fromJson(json.getJSONObject("publicKey")),
+          json.getString("x"));
+      return key.initFromJson();
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  JSONObject toJson() {
+    try {
+      return new JSONObject()
+        .put("size", size)
+        .put("publicKey", publicKey != null ? publicKey.toJson() : null)
+        .put("x", x);
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public DsaPrivateKey(DSAPrivateKey privateKey) throws KeyczarException {
@@ -69,11 +89,10 @@ public class DsaPrivateKey extends KeyczarKey implements KeyczarPrivateKey {
     x = Base64Coder.encodeWebSafe(jcePrivateKey.getX().toByteArray());
   }
 
-  // Used by GSON, which will overwrite the values set here.
-  private DsaPrivateKey() {
-    super(0);
-    publicKey = null;
-    x = null;
+  private DsaPrivateKey(int size, DsaPublicKey publicKey, String x) {
+    super(size);
+    this.publicKey = publicKey;
+    this.x = x;
   }
 
   @Override

--- a/java/code/src/org/keyczar/Encrypter.java
+++ b/java/code/src/org/keyczar/Encrypter.java
@@ -16,8 +16,6 @@
 
 package org.keyczar;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.keyczar.enums.KeyPurpose;
 import org.keyczar.exceptions.KeyczarException;
 import org.keyczar.exceptions.NoPrimaryKeyException;
@@ -42,8 +40,6 @@ import java.nio.ByteBuffer;
  *
  */
 public class Encrypter extends Keyczar {
-  private static final Logger LOG =
-    LoggerFactory.getLogger(Encrypter.class);
   private static final int ENCRYPT_CHUNK_SIZE = 1024;
   private final StreamQueue<EncryptingStream> ENCRYPT_QUEUE =
     new StreamQueue<EncryptingStream>();
@@ -129,7 +125,6 @@ public class Encrypter extends Keyczar {
    */
   public void encrypt(ByteBuffer input, ByteBuffer output)
       throws KeyczarException {
-    LOG.debug(Messages.getString("Encrypter.Encrypting", input.remaining()));
     KeyczarKey encryptingKey = getPrimaryKey();
     if (encryptingKey == null) {
       throw new NoPrimaryKeyException() ;

--- a/java/code/src/org/keyczar/GenericKeyczar.java
+++ b/java/code/src/org/keyczar/GenericKeyczar.java
@@ -1,7 +1,5 @@
 package org.keyczar;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.keyczar.enums.KeyPurpose;
 import org.keyczar.enums.KeyStatus;
 import org.keyczar.exceptions.KeyczarException;
@@ -26,7 +24,6 @@ import java.util.Set;
  *
  */
 class GenericKeyczar extends Keyczar {
-  private static final Logger LOG = LoggerFactory.getLogger(GenericKeyczar.class);
   GenericKeyczar(KeyczarReader reader) throws KeyczarException {
     super(reader);
   }
@@ -62,7 +59,6 @@ class GenericKeyczar extends Keyczar {
    */
   void promote(int versionNumber) throws KeyczarException {
     KeyVersion version = getVersion(versionNumber);
-    LOG.debug(Messages.getString("Keyczar.PromotedVersion", version));
     switch (version.getStatus()) {
       case PRIMARY:
         throw new KeyczarException(
@@ -90,7 +86,6 @@ class GenericKeyczar extends Keyczar {
    */
   void demote(int versionNumber) throws KeyczarException {
     KeyVersion version = getVersion(versionNumber);
-    LOG.debug(Messages.getString("Keyczar.DemotingVersion", version));
     switch (version.getStatus()) {
       case PRIMARY:
         version.setStatus(KeyStatus.ACTIVE);
@@ -145,7 +140,6 @@ class GenericKeyczar extends Keyczar {
       primaryVersion = version;
     }
     addKey(version, key);
-    LOG.debug(Messages.getString("Keyczar.NewVersion", version));
   }
 
   private int maxVersion() {

--- a/java/code/src/org/keyczar/HmacKey.java
+++ b/java/code/src/org/keyczar/HmacKey.java
@@ -16,8 +16,8 @@
 
 package org.keyczar;
 
-import com.google.gson.annotations.Expose;
-
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.keyczar.exceptions.KeyczarException;
 import org.keyczar.interfaces.KeyType;
 import org.keyczar.interfaces.SigningStream;
@@ -45,7 +45,7 @@ public class HmacKey extends KeyczarKey {
   private static final String MAC_ALGORITHM = "HMACSHA1";
   private static final int HMAC_DIGEST_SIZE = 20;
 
-  @Expose private final String hmacKeyString;
+  private final String hmacKeyString;
 
   private SecretKey hmacKey;
   private final byte[] hash = new byte[Keyczar.KEY_HASH_SIZE];
@@ -56,10 +56,9 @@ public class HmacKey extends KeyczarKey {
     initJceKey(keyBytes);
   }
 
-  // Used by GSON, which will overwrite the values set here.
-  private HmacKey() {
-    super(0);
-    hmacKeyString = null;
+  private HmacKey(int size, String hmacKeyString) {
+    super(size);
+    this.hmacKeyString = hmacKeyString;
   }
 
   static HmacKey generate(KeyParameters params) throws KeyczarException {
@@ -99,9 +98,30 @@ public class HmacKey extends KeyczarKey {
   }
 
   static HmacKey read(String input) throws KeyczarException {
-    HmacKey key = Util.gson().fromJson(input, HmacKey.class);
-    key.initFromJson();
-    return key;
+    try {
+      HmacKey key = fromJson(new JSONObject(input));
+      key.initFromJson();
+      return key;
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  static HmacKey fromJson(JSONObject json) throws JSONException {
+    return new HmacKey(
+        json.getInt("size"),
+        json.getString("hmacKeyString"));
+  }
+
+  @Override
+  JSONObject toJson() {
+    try {
+      return new JSONObject()
+        .put("size", size)
+        .put("hmacKeyString", hmacKeyString);
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override

--- a/java/code/src/org/keyczar/KeyMetadata.java
+++ b/java/code/src/org/keyczar/KeyMetadata.java
@@ -16,13 +16,14 @@
 
 package org.keyczar;
 
-import com.google.gson.annotations.Expose;
-
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.keyczar.enums.KeyPurpose;
 import org.keyczar.enums.KeyStatus;
 import org.keyczar.interfaces.KeyType;
-import org.keyczar.exceptions.NoPrimaryKeyException;
 import org.keyczar.util.Util;
+import org.keyczar.exceptions.NoPrimaryKeyException;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -51,29 +52,52 @@ import java.util.Map;
  *
  */
 public class KeyMetadata {
-  @Expose String name = "";
-  @Expose KeyPurpose purpose = KeyPurpose.TEST;
-  @Expose KeyType type = DefaultKeyType.TEST;
-  @Expose List<KeyVersion> versions = new ArrayList<KeyVersion>();
-  @Expose boolean encrypted = false;
+  String name = "";
+  KeyPurpose purpose = KeyPurpose.TEST;
+  KeyType type = DefaultKeyType.TEST;
+  List<KeyVersion> versions = new ArrayList<KeyVersion>();
+  boolean encrypted = false;
 
   protected Map<Integer, KeyVersion> versionMap =
       new HashMap<Integer, KeyVersion>(); // link version number to version
 
-  @SuppressWarnings("unused")
-  private KeyMetadata() {
-    // For GSON
-  }
-
-  KeyMetadata(String n, KeyPurpose p, KeyType t) {
+  public KeyMetadata(String n, KeyPurpose p, KeyType t) {
     name = n;
     purpose = p;
     type = t;
   }
 
+  private KeyMetadata(String name, KeyPurpose purpose, KeyType type,
+      List<KeyVersion> versions, boolean encrypted) {
+    this.name = name;
+    this.purpose = purpose;
+    this.type = type;
+    this.versions = versions;
+    this.encrypted = encrypted;
+  }
+
   @Override
   public String toString() {
-    return Util.gson().toJson(this);
+    try {
+      return new JSONObject()
+          .put("name", name)
+          .put("purpose", purpose != null ? purpose.name() : null)
+          .put("type", type != null ? type.getName() : null)
+          .put("versions", keyVersionsToJson())
+          .put("encrypted", encrypted)
+          .toString();
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private JSONArray keyVersionsToJson() {
+    JSONArray jsonArray = new JSONArray();
+    int max = versions.size();
+    for (int i = 0; i < max; i++) {
+      jsonArray.put(versions.get(i).toJson());
+    }
+    return jsonArray;
   }
 
   /**
@@ -82,7 +106,7 @@ public class KeyMetadata {
    * @param version KeyVersion of key to be added
    * @return true if add was successful, false if version number collides
    */
-  boolean addVersion(KeyVersion version) {
+  public boolean addVersion(KeyVersion version) {
     int versionNumber = version.getVersionNumber();
     if (!versionMap.containsKey(versionNumber)) {
       versionMap.put(versionNumber, version);
@@ -164,10 +188,29 @@ public class KeyMetadata {
    * @return KeyMetadata corresponding to JSON input
    */
   public static KeyMetadata read(String jsonString) {
-    KeyMetadata kmd = Util.gson().fromJson(jsonString, KeyMetadata.class);
-    for (KeyVersion version : kmd.getVersions()) {
-      kmd.versionMap.put(version.getVersionNumber(), version);
+    try {
+      JSONObject json = new JSONObject(jsonString);
+      KeyMetadata kmd = new KeyMetadata(
+          json.getString("name"),
+          Util.deserializeEnum(KeyPurpose.class, json.optString("purpose")),
+          new KeyType.KeyTypeDeserializer().deserialize(json.getString("type")),
+          buildVersions(json.getJSONArray("versions")),
+          json.getBoolean("encrypted"));
+      for (KeyVersion version : kmd.getVersions()) {
+        kmd.versionMap.put(version.getVersionNumber(), version);
+      }
+      return kmd;
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
     }
-    return kmd;
+  }
+
+  private static List<KeyVersion> buildVersions(JSONArray jsonArray) throws JSONException {
+    List<KeyVersion> list = new ArrayList<KeyVersion>();
+    int max = jsonArray.length();
+    for (int i = 0; i < max; i++) {
+      list.add(KeyVersion.fromJson(jsonArray.getJSONObject(i)));
+    }
+    return list;
   }
 }

--- a/java/code/src/org/keyczar/Keyczar.java
+++ b/java/code/src/org/keyczar/Keyczar.java
@@ -16,8 +16,6 @@
 
 package org.keyczar;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.keyczar.enums.KeyPurpose;
 import org.keyczar.enums.KeyStatus;
 import org.keyczar.exceptions.KeyczarException;
@@ -36,7 +34,6 @@ import java.util.HashMap;
  *
  */
 abstract class Keyczar {
-  private static final Logger LOG = LoggerFactory.getLogger(Keyczar.class);
   static final String DEFAULT_ENCODING = "UTF-8";
   static final byte FORMAT_VERSION = 0;
   static final byte[] FORMAT_BYTES = { FORMAT_VERSION };
@@ -99,7 +96,6 @@ abstract class Keyczar {
       }
       String keyString = reader.getKey(version.getVersionNumber());
       KeyczarKey key = kmd.getType().getBuilder().read(keyString);
-      LOG.debug(Messages.getString("Keyczar.ReadVersion", version));
       hashMap.put(new KeyHash(key.hash()), key);
       versionMap.put(version, key);
     }

--- a/java/code/src/org/keyczar/KeyczarKey.java
+++ b/java/code/src/org/keyczar/KeyczarKey.java
@@ -16,8 +16,7 @@
 
 package org.keyczar;
 
-import com.google.gson.annotations.Expose;
-
+import org.json.JSONObject;
 import org.keyczar.exceptions.KeyczarException;
 import org.keyczar.i18n.Messages;
 import org.keyczar.interfaces.KeyType;
@@ -52,7 +51,7 @@ public abstract class KeyczarKey {
   private static final String PEM_LINE_ENDING = "-----\n";
   private static final String PEM_HEADER_BEGIN = "-----BEGIN ";
 
-  @Expose final int size;
+  final int size;
 
   private static final int PBE_SALT_SIZE = 8;
   private static final int IV_SIZE = 16;
@@ -122,8 +121,10 @@ public abstract class KeyczarKey {
 
   @Override
   public String toString() {
-    return Util.gson().toJson(this);
+    return toJson().toString();
   }
+
+  abstract JSONObject toJson();
 
   /**
    * Returns a PKCS8 PEM-format string containing the key information.

--- a/java/code/src/org/keyczar/MockKeyczarReader.java
+++ b/java/code/src/org/keyczar/MockKeyczarReader.java
@@ -49,7 +49,7 @@ public class MockKeyczarReader implements KeyczarReader {
 
   @Override
   public String getMetadata() {
-    return Util.gson().toJson(kmd);
+    return kmd.toString();
   }
 
   public void setMetadata(KeyMetadata newKmd) {

--- a/java/code/src/org/keyczar/RsaPrivateKey.java
+++ b/java/code/src/org/keyczar/RsaPrivateKey.java
@@ -19,8 +19,8 @@ package org.keyczar;
 import static org.keyczar.util.Util.decodeBigInteger;
 import static org.keyczar.util.Util.encodeBigInteger;
 
-import com.google.gson.annotations.Expose;
-
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.keyczar.enums.RsaPadding;
 import org.keyczar.exceptions.KeyczarException;
 import org.keyczar.interfaces.DecryptingStream;
@@ -54,13 +54,13 @@ import javax.crypto.ShortBufferException;
 public class RsaPrivateKey extends KeyczarKey implements KeyczarPrivateKey {
   private static final String KEY_GEN_ALGORITHM = "RSA";
 
-  @Expose private final RsaPublicKey publicKey;
-  @Expose private final String privateExponent;
-  @Expose private final String primeP;
-  @Expose private final String primeQ;
-  @Expose private final String primeExponentP;
-  @Expose private final String primeExponentQ;
-  @Expose private final String crtCoefficient;
+  private final RsaPublicKey publicKey;
+  private final String privateExponent;
+  private final String primeP;
+  private final String primeQ;
+  private final String primeExponentP;
+  private final String primeExponentQ;
+  private final String crtCoefficient;
 
   private static final String SIG_ALGORITHM = "SHA1withRSA";
 
@@ -73,8 +73,21 @@ public class RsaPrivateKey extends KeyczarKey implements KeyczarPrivateKey {
   }
 
   static RsaPrivateKey read(String input) throws KeyczarException {
-    RsaPrivateKey key = Util.gson().fromJson(input, RsaPrivateKey.class);
-    return key.initFromJson();
+    try {
+      JSONObject json = new JSONObject(input);
+      return new RsaPrivateKey(
+          json.getInt("size"),
+          RsaPublicKey.fromJson(json.getJSONObject("publicKey")),
+          json.getString("privateExponent"),
+          json.getString("primeP"),
+          json.getString("primeQ"),
+          json.getString("primeExponentP"),
+          json.getString("primeExponentQ"),
+          json.getString("crtCoefficient"))
+          .initFromJson();
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public RsaPrivateKey(RSAPrivateCrtKey privateKey, RsaPadding padding) throws KeyczarException {
@@ -89,16 +102,36 @@ public class RsaPrivateKey extends KeyczarKey implements KeyczarPrivateKey {
     jcePrivateKey = privateKey;
   }
 
-  private RsaPrivateKey() {
-    super(0);
-    publicKey = null;
-    privateExponent = null;
-    primeP = null;
-    primeQ = null;
-    primeExponentP = null;
-    primeExponentQ = null;
-    crtCoefficient = null;
+  // Used for JSOn
+  private RsaPrivateKey(int size, RsaPublicKey publicKey, String privateExponent,
+      String primeP, String primeQ, String primeExponentP, String primeExponentQ,
+      String crtCoefficient) {
+    super(size);
+    this.publicKey = publicKey;
+    this.privateExponent = privateExponent;
+    this.primeP = primeP;
+    this.primeQ = primeQ;
+    this.primeExponentP = primeExponentP;
+    this.primeExponentQ = primeExponentQ;
+    this.crtCoefficient = crtCoefficient;
     jcePrivateKey = null;
+  }
+
+  @Override
+  JSONObject toJson() {
+    try {
+      return new JSONObject()
+        .put("size", size)
+        .put("publicKey", publicKey != null ? publicKey.toJson() : null)
+        .put("privateExponent", privateExponent)
+        .put("primeP", primeP)
+        .put("primeQ", primeQ)
+        .put("primeExponentP", primeExponentP)
+        .put("primeExponentQ", primeExponentQ)
+        .put("crtCoefficient", crtCoefficient);
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override

--- a/java/code/src/org/keyczar/RsaPublicKey.java
+++ b/java/code/src/org/keyczar/RsaPublicKey.java
@@ -16,9 +16,8 @@
 
 package org.keyczar;
 
-
-import com.google.gson.annotations.Expose;
-
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.keyczar.enums.RsaPadding;
 import org.keyczar.exceptions.KeyczarException;
 import org.keyczar.exceptions.UnsupportedTypeException;
@@ -55,19 +54,44 @@ public class RsaPublicKey extends KeyczarPublicKey {
   private static final String SIG_ALGORITHM = "SHA1withRSA";
 
   private RSAPublicKey jcePublicKey;
-  @Expose final String modulus;
-  @Expose final String publicExponent;
-  @Expose final RsaPadding padding;
+  final String modulus;
+  final String publicExponent;
+  final RsaPadding padding;
 
   private final byte[] hash = new byte[Keyczar.KEY_HASH_SIZE];
 
   static RsaPublicKey read(String input) throws KeyczarException {
-    RsaPublicKey key = Util.gson().fromJson(input, RsaPublicKey.class);
+    try {
+      return fromJson(new JSONObject(input));
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  static RsaPublicKey fromJson(JSONObject json) throws KeyczarException, JSONException {
+    RsaPublicKey key = new RsaPublicKey(
+        json.getInt("size"),
+        json.getString("modulus"),
+        json.getString("publicExponent"),
+        Util.deserializeEnum(RsaPadding.class, json.optString("padding")));
 
     if (key.getType() != DefaultKeyType.RSA_PUB) {
       throw new UnsupportedTypeException(key.getType());
     }
     return key.initFromJson();
+  }
+
+  @Override
+  JSONObject toJson() {
+    try {
+      return new JSONObject()
+        .put("size", size)
+        .put("modulus", modulus)
+        .put("publicExponent", publicExponent)
+        .put("padding", padding != null ? padding.name() : null);
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override
@@ -97,11 +121,12 @@ public class RsaPublicKey extends KeyczarPublicKey {
     initializeHash();
   }
 
-  // Used by GSON, which will overwrite the values set here.
-  private RsaPublicKey() {
-    super(0);
-    modulus = publicExponent = null;
-    padding = null;
+  // Used for JSON
+  private RsaPublicKey(int size, String modulus, String publicExponent, RsaPadding padding) {
+    super(size);
+    this.modulus = modulus;
+    this.publicExponent = publicExponent;
+    this.padding = padding;
   }
 
   private RsaPublicKey(BigInteger mod, BigInteger exp, RsaPadding padding) {

--- a/java/code/src/org/keyczar/Signer.java
+++ b/java/code/src/org/keyczar/Signer.java
@@ -16,8 +16,6 @@
 
 package org.keyczar;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.keyczar.enums.KeyPurpose;
 import org.keyczar.exceptions.KeyczarException;
 import org.keyczar.exceptions.NoPrimaryKeyException;
@@ -43,7 +41,6 @@ import java.nio.ByteBuffer;
  */
 public class Signer extends Verifier {
   static final int TIMESTAMP_SIZE = 8;
-  private static final Logger LOG = LoggerFactory.getLogger(Signer.class);
   private final StreamQueue<SigningStream> SIGN_QUEUE = new StreamQueue<SigningStream>();
 
   /**
@@ -128,9 +125,6 @@ public class Signer extends Verifier {
    */
   void sign(ByteBuffer input, ByteBuffer hidden, long expirationTime, ByteBuffer output)
       throws KeyczarException {
-    if (LOG.isDebugEnabled()) {
-      LOG.debug(Messages.getString("Signer.Signing", input.remaining()));
-    }
     KeyczarKey signingKey = getPrimaryKey();
     if (signingKey == null) {
       throw new NoPrimaryKeyException();

--- a/java/code/src/org/keyczar/UnversionedSigner.java
+++ b/java/code/src/org/keyczar/UnversionedSigner.java
@@ -16,8 +16,6 @@
 
 package org.keyczar;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.keyczar.enums.KeyPurpose;
 import org.keyczar.exceptions.KeyczarException;
 import org.keyczar.exceptions.NoPrimaryKeyException;
@@ -46,7 +44,6 @@ import java.nio.ByteBuffer;
  */
 public class UnversionedSigner extends UnversionedVerifier {
   static final int TIMESTAMP_SIZE = 8;
-  private static final Logger LOG = LoggerFactory.getLogger(UnversionedSigner.class);
   private final StreamQueue<SigningStream> SIGN_QUEUE =
     new StreamQueue<SigningStream>();
 
@@ -118,7 +115,6 @@ public class UnversionedSigner extends UnversionedVerifier {
    * @throws KeyczarException
    */
   void sign(ByteBuffer input, ByteBuffer output) throws KeyczarException {
-    LOG.debug(Messages.getString("Signer.Signing", input.remaining()));
     KeyczarKey signingKey = getPrimaryKey();
     if (signingKey == null) {
       throw new NoPrimaryKeyException();

--- a/java/code/src/org/keyczar/UnversionedVerifier.java
+++ b/java/code/src/org/keyczar/UnversionedVerifier.java
@@ -16,8 +16,6 @@
 
 package org.keyczar;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.keyczar.enums.KeyPurpose;
 import org.keyczar.exceptions.KeyczarException;
 import org.keyczar.i18n.Messages;
@@ -44,8 +42,6 @@ import java.nio.ByteBuffer;
 *
 */
 public class UnversionedVerifier extends Keyczar {
-  private static final Logger LOG =
-    LoggerFactory.getLogger(UnversionedVerifier.class);
   private static final StreamCache<VerifyingStream> VERIFY_CACHE
     = new StreamCache<VerifyingStream>();
 
@@ -103,8 +99,6 @@ public class UnversionedVerifier extends Keyczar {
    */
   public boolean verify(ByteBuffer data, ByteBuffer signature)
       throws KeyczarException {
-    LOG.debug(Messages.getString("UnversionedVerifier.Verifying", data.remaining()));
-
     for (KeyczarKey key : versionMap.values()) {
       if (verify(data, signature, key)) {
         return true;

--- a/java/code/src/org/keyczar/Verifier.java
+++ b/java/code/src/org/keyczar/Verifier.java
@@ -17,8 +17,6 @@
 package org.keyczar;
 
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.keyczar.enums.KeyPurpose;
 import org.keyczar.exceptions.BadVersionException;
 import org.keyczar.exceptions.KeyNotFoundException;
@@ -46,7 +44,6 @@ import java.nio.ByteBuffer;
 *
 */
 public class Verifier extends Keyczar {
-  private static final Logger LOG = LoggerFactory.getLogger(Verifier.class);
   private final StreamCache<VerifyingStream> VERIFY_CACHE
     = new StreamCache<VerifyingStream>();
 
@@ -117,7 +114,6 @@ public class Verifier extends Keyczar {
    */
   boolean verify(ByteBuffer data, ByteBuffer hidden,
       ByteBuffer signature) throws KeyczarException {
-    LOG.debug(Messages.getString("Verifier.Verifying", data.remaining()));
     if (signature.remaining() < HEADER_SIZE) {
       throw new ShortSignatureException(signature.remaining());
     }

--- a/java/code/src/org/keyczar/enums/CipherMode.java
+++ b/java/code/src/org/keyczar/enums/CipherMode.java
@@ -16,7 +16,6 @@
 
 package org.keyczar.enums;
 
-import com.google.gson.annotations.Expose;
 /**
  * Encodes different modes of operation:
  *   Cipher Block Chaining (CBC) with initial value (IV)
@@ -28,40 +27,19 @@ import com.google.gson.annotations.Expose;
  *
  */
 public enum CipherMode {
-  CBC(0, "AES/CBC/PKCS5Padding", true),
-  CTR(1, "AES/CTR/NoPadding", true),
-  ECB(2, "AES/ECB/NoPadding", false),
-  DET_CBC(3, "AES/CBC/PKCS5Padding", false);
+  CBC("AES/CBC/PKCS5Padding"),
+  CTR("AES/CTR/NoPadding"),
+  ECB("AES/ECB/NoPadding"),
+  DET_CBC("AES/CBC/PKCS5Padding");
 
   private String jceMode;
-  @Expose
-  private int value;
 
-  private CipherMode(int v, String s, boolean useIv) {
-    value = v;
+  private CipherMode(String s) {
     jceMode = s;
   }
 
   public String getMode() {
     return jceMode;
-  }
-
-  int getValue() {
-    return value;
-  }
-
-  static CipherMode getMode(int value) {
-    switch (value) {
-      case 0:
-        return CBC;
-      case 1:
-        return CTR;
-      case 2:
-        return ECB;
-      case 3:
-        return DET_CBC;
-    }
-    return null;
   }
 
   public int getOutputSize(int blockSize, int inputLength) {

--- a/java/code/src/org/keyczar/enums/KeyPurpose.java
+++ b/java/code/src/org/keyczar/enums/KeyPurpose.java
@@ -39,24 +39,18 @@ package org.keyczar.enums;
  *  
  */
 public enum KeyPurpose {
-  DECRYPT_AND_ENCRYPT(0, "crypt"), 
-  ENCRYPT(1, "encrypt"), 
-  SIGN_AND_VERIFY(2, "sign"),
-  VERIFY(3, "verify"),
-  TEST(127, "test");
+  DECRYPT_AND_ENCRYPT("crypt"),
+  ENCRYPT("encrypt"),
+  SIGN_AND_VERIFY("sign"),
+  VERIFY("verify"),
+  TEST("test");
 
-  private int value;
   private String name;
 
-  private KeyPurpose(int v, String s) {
-    value = v;
+  private KeyPurpose(String s) {
     name = s;
   }
 
-  int getValue() {
-    return value;
-  }
-  
   String getName() {
     return name;
   }

--- a/java/code/src/org/keyczar/enums/KeyStatus.java
+++ b/java/code/src/org/keyczar/enums/KeyStatus.java
@@ -38,20 +38,14 @@ package org.keyczar.enums;
  *  
  */
 public enum KeyStatus {
-  PRIMARY(0, "primary"), 
-  ACTIVE(1, "active"),
-  INACTIVE(2, "inactive");
+  PRIMARY("primary"),
+  ACTIVE("active"),
+  INACTIVE("inactive");
 
-  private int value;
   private String name;
 
-  private KeyStatus(int v, String s) {
-    value = v;
+  private KeyStatus(String s) {
     name = s;
-  }
-
-  int getValue() {
-    return value;
   }
   
   String getName() {

--- a/java/code/src/org/keyczar/interfaces/KeyType.java
+++ b/java/code/src/org/keyczar/interfaces/KeyType.java
@@ -16,20 +16,11 @@
 
 package org.keyczar.interfaces;
 
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
-
 import org.keyczar.DefaultKeyType;
 import org.keyczar.KeyczarKey;
 import org.keyczar.exceptions.KeyczarException;
 import org.keyczar.keyparams.KeyParameters;
 
-import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -95,20 +86,9 @@ public interface KeyType {
   public Builder getBuilder();
 
   /**
-   * Serializer based on the key type's value.
-   */
-  public static class KeyTypeSerializer implements JsonSerializer<KeyType> {
-    @Override
-    public JsonElement serialize(KeyType src,
-        Type type, JsonSerializationContext context) {
-      return new JsonPrimitive(src.getName());
-    }
-  }
-
-  /**
    * Trivial deserialization based on the key value.
    */
-  public static class KeyTypeDeserializer implements JsonDeserializer<KeyType> {
+  public static class KeyTypeDeserializer {
     private static Map<String, KeyType> typeMap =
         new HashMap<String, KeyType>();
 
@@ -138,10 +118,7 @@ public interface KeyType {
       typeMap.put(name, keyType);
     }
 
-    @Override
-    public KeyType deserialize(JsonElement json, Type type,
-        JsonDeserializationContext context) throws JsonParseException {
-      String keyName = json.getAsJsonPrimitive().getAsString();
+    public KeyType deserialize(String keyName) {
       if (!typeMap.containsKey(keyName)) {
         throw new IllegalArgumentException("Cannot deserialize "
             + keyName + " no such key has been registered.");

--- a/java/code/src/org/keyczar/interop/Creator.java
+++ b/java/code/src/org/keyczar/interop/Creator.java
@@ -1,26 +1,65 @@
 package org.keyczar.interop;
 
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.keyczar.KeyczarTool;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Class used for gson data to call create commands
+ * Class used for json data to call create commands
  */
 public class Creator {
   @SuppressWarnings("unused")
   private final String command;
   private final List<List<String>> keyczartCommands;
-  
+
   public Creator(String command, List<List<String>> keyczartCommands) {
     this.command = command;
     this.keyczartCommands = keyczartCommands;
   }
-  
+
   public void create() {
     for (List<String> keyczartCommand : keyczartCommands) {
       String [] args = keyczartCommand.toArray(new String[keyczartCommand.size()]);
       KeyczarTool.main(args);
     }
+  }
+
+  static Creator read(String jsonString) {
+    try {
+      JSONObject json = new JSONObject(jsonString);
+      return new Creator(
+          json.optString("command"),
+          buildKeyczartCommands(json.optJSONArray("keyczartCommands")));
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static List<List<String>> buildKeyczartCommands(JSONArray jsonArray)
+      throws JSONException {
+    List<List<String>> list = new ArrayList<List<String>>();
+    if (jsonArray != null) {
+      int max = jsonArray.length();
+      for (int i = 0; i < max; i++) {
+        JSONArray innerListJsonArray = jsonArray.optJSONArray(i);
+        list.add(toListOfStrings(innerListJsonArray));
+      }
+    }
+    return list;
+  }
+
+  private static List<String> toListOfStrings(JSONArray jsonArray) throws JSONException {
+    List<String> list = new ArrayList<String>();
+    if (jsonArray != null) {
+      int max = jsonArray.length();
+      for (int i = 0; i < max; i++) {
+        list.add(jsonArray.getString(i));
+      }
+    }
+    return list;
   }
 }

--- a/java/code/src/org/keyczar/interop/Generator.java
+++ b/java/code/src/org/keyczar/interop/Generator.java
@@ -1,10 +1,14 @@
 package org.keyczar.interop;
 
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.keyczar.exceptions.KeyczarException;
 import org.keyczar.interop.operations.Operation;
+import org.keyczar.util.Util;
 
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Class used for gson data to call generate commands
@@ -35,5 +39,19 @@ public class Generator {
     byte[] output = op.generate(algorithm, generateOptions);
     return op.formatOutput(output);
   }
-  
+
+  static Generator read(String jsonString) {
+    try {
+      JSONObject json = new JSONObject(jsonString);
+    return new Generator(
+        json.optString("command"),
+        json.optString("operation"),
+        json.optString("keyPath"),
+        json.optString("algorithm"),
+        Util.deserializeMap(json.optJSONObject("generateOptions")),
+        json.optString("testData"));
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
+  }
 }

--- a/java/code/src/org/keyczar/interop/Interop.java
+++ b/java/code/src/org/keyczar/interop/Interop.java
@@ -1,9 +1,7 @@
 package org.keyczar.interop;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.keyczar.exceptions.KeyczarException;
 
 /**
@@ -17,11 +15,10 @@ public class Interop {
    */
   public static void main(String[] args) {
 
-    Gson gson = new Gson();
     switch (getCommandType(args[0])) {
       case GENERATE:
         // initializes generator from json and then prints output
-        Generator generator = gson.fromJson(args[0], Generator.class);
+        Generator generator = Generator.read(args[0]);
         try {
           String output = generator.generate();
           if (output != null) {
@@ -33,12 +30,12 @@ public class Interop {
         }
         break;
       case CREATE:
-        Creator creator = gson.fromJson(args[0], Creator.class);
+        Creator creator = Creator.read(args[0]);
         creator.create();
         break;
       case TEST:
         // initializes tester from json and then throws error if it fails
-        Tester tester = gson.fromJson(args[0], Tester.class);
+        Tester tester = Tester.read(args[0]);
         try {
           tester.test();
         } catch (KeyczarException e) {
@@ -58,8 +55,10 @@ public class Interop {
    * @return command enum
    */
   private static InteropCommand getCommandType(String jsonString) {
-    JsonParser parser = new JsonParser();
-    JsonObject object = parser.parse(jsonString).getAsJsonObject();
-    return InteropCommand.getCommand(object.get("command").getAsString());
+    try {
+      return InteropCommand.getCommand(new JSONObject(jsonString).getString("command"));
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/java/code/src/org/keyczar/interop/Tester.java
+++ b/java/code/src/org/keyczar/interop/Tester.java
@@ -1,10 +1,12 @@
 package org.keyczar.interop;
 
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.keyczar.exceptions.KeyczarException;
 import org.keyczar.interop.operations.Operation;
+import org.keyczar.util.Util;
 
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Class used for gson data to call test commands
@@ -19,7 +21,7 @@ public class Tester {
   private final Map<String, String> testOptions;
   private final Map<String, String> output;
   private final String testData;
-  
+
   public Tester(
       String command, String operation, String keyPath, String algorithm, 
       Map<String, String> generateOptions, Map<String, String> testOptions,
@@ -33,9 +35,26 @@ public class Tester {
     this.output = output;
     this.testData = testData;
   }
-  
+
   public void test() throws KeyczarException {
     Operation op = Operation.getOperationByName(operation, keyPath, testData);
     op.test(output, algorithm, generateOptions, testOptions);
+  }
+
+  static Tester read(String jsonString) {
+    try {
+      JSONObject json = new JSONObject(jsonString);
+      return new Tester(
+          json.optString("command"),
+          json.optString("operation"),
+          json.optString("keyPath"),
+          json.optString("algorithm"),
+          Util.deserializeMap(json.optJSONObject("generateOptions")),
+          Util.deserializeMap(json.optJSONObject("testOptions")),
+          Util.deserializeMap(json.optJSONObject("output")),
+          json.optString("testData"));
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/java/code/src/org/keyczar/interop/operations/Operation.java
+++ b/java/code/src/org/keyczar/interop/operations/Operation.java
@@ -16,8 +16,8 @@
 
 package org.keyczar.interop.operations;
 
-import com.google.gson.Gson;
-
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.keyczar.Crypter;
 import org.keyczar.KeyczarEncryptedReader;
 import org.keyczar.KeyczarFileReader;
@@ -142,7 +142,7 @@ public abstract class Operation {
   }
 
   /**
-   * Object for gson formatting of output data
+   * Object for json formatting of output data
    */
   static class Output {
     public final String output;
@@ -155,17 +155,20 @@ public abstract class Operation {
   /**
    * Takes a byte array and returns a json formatted string with output
    * @param output
-   * @return
    */
   public String formatOutput(byte[] output){
-    Gson gson = new Gson();
-    return gson.toJson(new Output(output));
+    JSONObject json = new JSONObject();
+    try {
+      json.put("output", new Output(output).output);
+      return json.toString();
+    } catch (JSONException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   /**
    * Undoes formatting of formatOutput (takes in json string returns bytes)
    * @param output
-   * @return
    * @throws Base64DecodingException
    */
   public byte[] readOutput(Map<String, String> output) throws Base64DecodingException{

--- a/java/code/src/org/keyczar/util/Util.java
+++ b/java/code/src/org/keyczar/util/Util.java
@@ -16,12 +16,10 @@
 
 package org.keyczar.util;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.keyczar.exceptions.Base64DecodingException;
 import org.keyczar.exceptions.KeyczarException;
-import org.keyczar.interfaces.KeyType;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -35,7 +33,10 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 /**
@@ -54,21 +55,6 @@ public class Util {
 
   private Util() {
     // Don't new me.
-  }
-
-  private static final ThreadLocal<Gson> GSON_THREAD_LOCAL = new ThreadLocal<Gson>() {
-    @Override
-    protected Gson initialValue() {
-      return new GsonBuilder()
-        .excludeFieldsWithoutExposeAnnotation()
-        .registerTypeAdapter(KeyType.class, new KeyType.KeyTypeSerializer())
-        .registerTypeAdapter(KeyType.class, new KeyType.KeyTypeDeserializer())
-        .create();
-    }
-  };
-
-  public static Gson gson() {
-    return GSON_THREAD_LOCAL.get();
   }
 
   public static byte[] stripLeadingZeros(byte[] input) {
@@ -469,5 +455,26 @@ public class Util {
     } catch (GeneralSecurityException e) {
       throw new KeyczarException(e);
     }
+  }
+
+  public static <T extends Enum<T>> T deserializeEnum(Class<T> enumType, String name) {
+    if (name == null || name.isEmpty()) {
+      return null;
+    }
+    return Enum.valueOf(enumType, name);
+  }
+
+  public static Map<String, String> deserializeMap(JSONObject jsonObject)
+      throws JSONException {
+    Map<String, String> map = new HashMap<String, String>();
+    if (jsonObject != null) {
+      Iterator<String> iter = jsonObject.keys();
+      while (iter.hasNext()) {
+        String key = iter.next();
+        String value = jsonObject.getString(key);
+        map.put(key,  value);
+      }
+    }
+    return map;
   }
 }

--- a/java/code/tests/org/keyczar/CrypterTest.java
+++ b/java/code/tests/org/keyczar/CrypterTest.java
@@ -22,8 +22,6 @@ import java.util.Arrays;
 
 import junit.framework.TestCase;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.junit.Test;
 import org.keyczar.exceptions.KeyNotFoundException;
 import org.keyczar.exceptions.KeyczarException;
@@ -38,7 +36,6 @@ import org.keyczar.interfaces.KeyczarReader;
  */
 
 public class CrypterTest extends TestCase {
-  private static final Logger LOG = LoggerFactory.getLogger(CrypterTest.class);
   private static final String TEST_DATA = "./testdata";
   private String input = "This is some test data";
 
@@ -88,7 +85,6 @@ public class CrypterTest extends TestCase {
   public final void testAesEncryptAndDecrypt() throws KeyczarException {
     Crypter crypter = new Crypter(TEST_DATA + "/aes");
     String ciphertext = crypter.encrypt(input);
-    LOG.debug(String.format("Aes Ciphertext: %s", ciphertext));
     String decrypted = crypter.decrypt(ciphertext);
     assertEquals(input, decrypted);
   }
@@ -97,7 +93,6 @@ public class CrypterTest extends TestCase {
   public final void testRsaEncryptAndDecryptWithCrypter() throws KeyczarException {
     Crypter crypter = new Crypter(TEST_DATA + "/rsa");
     String ciphertext = crypter.encrypt(input);
-    LOG.debug(String.format("Rsa Ciphertext: %s", ciphertext));
     String decrypted = crypter.decrypt(ciphertext);
     assertEquals(input, decrypted);
   }
@@ -106,7 +101,6 @@ public class CrypterTest extends TestCase {
   public final void testRsaEncryptAndDecryptWithEncrypter() throws KeyczarException {
     Encrypter encrypter = new Encrypter(TEST_DATA + "/rsa.public");
     String ciphertext = encrypter.encrypt(input);
-    LOG.debug(String.format("Rsa Ciphertext: %s", ciphertext));
     Crypter crypter = new Crypter(TEST_DATA + "/rsa");
     String decrypted = crypter.decrypt(ciphertext);
     assertEquals(input, decrypted);

--- a/java/code/tests/org/keyczar/RsaPaddingTest.java
+++ b/java/code/tests/org/keyczar/RsaPaddingTest.java
@@ -25,8 +25,6 @@ import org.keyczar.exceptions.KeyNotFoundException;
 import org.keyczar.exceptions.KeyczarException;
 import org.keyczar.interfaces.KeyczarReader;
 
-import com.google.gson.JsonParseException;
-
 /**
  * This test case verifies that OAEP and PKCS1 v1.5 padding are both supported for RSA keys.
  *
@@ -117,7 +115,7 @@ public class RsaPaddingTest extends TestCase {
     try {
       new Encrypter(invalidReader);
       fail("Should throw");
-    } catch (JsonParseException e) {
+    } catch (RuntimeException e) {
       assertTrue(e.getMessage().contains("INVALID"));
     }
   }

--- a/java/code/tests/org/keyczar/SessionTest.java
+++ b/java/code/tests/org/keyczar/SessionTest.java
@@ -18,8 +18,6 @@ package org.keyczar;
 
 import junit.framework.TestCase;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.junit.Test;
 import org.keyczar.exceptions.KeyczarException;
 import org.keyczar.util.Base64Coder;
@@ -36,7 +34,6 @@ import java.util.Arrays;
  */
 @SuppressWarnings("deprecation")
 public class SessionTest extends TestCase {
-  private static final Logger LOG = LoggerFactory.getLogger(SessionTest.class);
   private static final String TEST_DATA = "./testdata";
   private String input = "This is some test data";
   // Bigger than a public key block
@@ -59,10 +56,8 @@ public class SessionTest extends TestCase {
   public final void testEncryptAndDecrypt() throws KeyczarException {
     byte[] sessionMaterial = sessionEncrypter.getSessionMaterial();
     String sessionMaterialString = Base64Coder.encodeWebSafe(sessionMaterial);
-    LOG.debug(String.format("Encoded session material: %s", sessionMaterialString));
     byte[] ciphertext = sessionEncrypter.encrypt(input.getBytes());
     String ciphertextString = Base64Coder.encodeWebSafe(ciphertext);
-    LOG.debug(String.format("Encoded ciphertext: %s", ciphertextString));
     sessionDecrypter = new SessionDecrypter(privateKeyDecrypter, sessionMaterial);
     byte[] plaintext = sessionDecrypter.decrypt(ciphertext);
     String decrypted = new String(plaintext);
@@ -119,7 +114,6 @@ public class SessionTest extends TestCase {
   public final void testCrypterDecryptsOwnCiphertext() throws KeyczarException {
     byte[] ciphertext = sessionCrypter.encrypt(input.getBytes());
     String ciphertextString = Base64Coder.encodeWebSafe(ciphertext);
-    LOG.debug(String.format("Encoded ciphertext: %s", ciphertextString));
 
     byte[] plaintext = sessionCrypter.decrypt(ciphertext);
     String decrypted = new String(plaintext);

--- a/java/code/tests/org/keyczar/SignedSessionTest.java
+++ b/java/code/tests/org/keyczar/SignedSessionTest.java
@@ -22,8 +22,6 @@ import java.util.Arrays;
 
 import junit.framework.TestCase;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.junit.Test;
 import org.keyczar.annotations.Experimental;
 import org.keyczar.exceptions.KeyczarException;
@@ -37,7 +35,6 @@ import org.keyczar.util.Base64Coder;
  */
 @Experimental
 public class SignedSessionTest extends TestCase {
-  private static final Logger LOG = LoggerFactory.getLogger(SignedSessionTest.class);
   private static final String TEST_DATA = "./testdata";
   private String input = "This is some test data";
   // Bigger than a public key block
@@ -63,12 +60,10 @@ public class SignedSessionTest extends TestCase {
   public final void testEncryptAndDecrypt() throws KeyczarException {
     // create a new session, already encrypted and encoded.
     String sessionMaterialString = sessionEncrypter.newSession();
-    LOG.debug(String.format("Encoded session material: %s", sessionMaterialString));
 
     // perform encryption
     byte[] ciphertext = sessionEncrypter.encrypt(input.getBytes());
     String ciphertextString = Base64Coder.encodeWebSafe(ciphertext);
-    LOG.debug(String.format("Encoded ciphertext: %s", ciphertextString));
 
     // perform decryption
     sessionDecrypter =
@@ -93,12 +88,10 @@ public class SignedSessionTest extends TestCase {
 
     // create a new session, already encrypted and encoded.
     String sessionMaterialString = sessionEncrypter.newSession();
-    LOG.debug(String.format("Encoded session material: %s", sessionMaterialString));
 
     // perform encryption
     byte[] ciphertext = sessionEncrypter.encrypt(input.getBytes());
     String ciphertextString = Base64Coder.encodeWebSafe(ciphertext);
-    LOG.debug(String.format("Encoded ciphertext: %s", ciphertextString));
 
     // perform decryption
     sessionDecrypter =

--- a/java/code/tests/org/keyczar/SignerTest.java
+++ b/java/code/tests/org/keyczar/SignerTest.java
@@ -22,8 +22,6 @@ import java.nio.ByteBuffer;
 
 import junit.framework.TestCase;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.junit.Test;
 import org.keyczar.exceptions.BadVersionException;
 import org.keyczar.exceptions.KeyNotFoundException;
@@ -37,7 +35,6 @@ import org.keyczar.exceptions.ShortSignatureException;
  *
  */
 public class SignerTest extends TestCase {
-  private static final Logger LOG = LoggerFactory.getLogger(SignerTest.class);
   private static final String TEST_DATA = "./testdata";
   private String input = "This is some test data";
   private byte[] inputBytes = input.getBytes();
@@ -98,7 +95,6 @@ public class SignerTest extends TestCase {
     Signer hmacSigner = new Signer(TEST_DATA + "/hmac");
     String sig = hmacSigner.sign(input);
     assertTrue(hmacSigner.verify(input, sig));
-    LOG.debug(String.format("Hmac Sig: %s", sig));
     // Try signing and verifying directly in a buffer
     ByteBuffer buffer =
       ByteBuffer.allocate(inputBytes.length + hmacSigner.digestSize());
@@ -126,7 +122,6 @@ public class SignerTest extends TestCase {
   public final void testDsaSignAndVerify() throws KeyczarException {
     Signer dsaSigner = new Signer(TEST_DATA + "/dsa");
     String sig = dsaSigner.sign(input);
-    LOG.debug(String.format("Dsa Sig: %s", sig));
     assertTrue(dsaSigner.verify(input, sig));
     assertFalse(dsaSigner.verify("Wrong string", sig));
   }
@@ -146,7 +141,6 @@ public class SignerTest extends TestCase {
   public final void testRsaSignAndVerify() throws KeyczarException {
     Signer rsaSigner = new Signer(TEST_DATA + "/rsa-sign");
     String sig = rsaSigner.sign(input);
-    LOG.debug(String.format("Rsa Sig: %s", sig));
     assertTrue(rsaSigner.verify(input, sig));
     assertFalse(rsaSigner.verify("Wrong string", sig));
   }


### PR DESCRIPTION
- Replace gson with org.json.JSONObject api. Note that android includes org.json in the framework, so if deploying keyczar to android don't bundle org.json. Deleted unused fields and methods on some enums. In general, I tried to be forgiving while converting objects to JSON (as that's how toString() is often implemented, which should not crash since we need that for debugging), but strict while parsing JSON.
- Remove all java logging.

Tests still pass. :-)

Note: previously, errors during JSON parsing threw unchecked gson exceptions. Now we throw RuntimeExceptions wrapping checked JSONException.

I don't know how to test Eclipse/Maven project integration.
