### PR TITLE
adding compatiblity with django-environ (Path)

### DIFF
--- a/python/src/keyczar/readers.py
+++ b/python/src/keyczar/readers.py
@@ -113,6 +113,8 @@ class FileReader(Reader):
   @classmethod
   def CreateReader(cls, location):
     result = None
+    location = str(location) # This fixes the case in case the location is
+                             # an instance of Path (from django-environ)
     if os.path.exists(location):
       result = FileReader(location)
     return result


### PR DESCRIPTION
`keyczar` (python) isn't compatible with Path (from [django-environ](https://github.com/joke2k/django-environ)) - this pull request adds a simple fix.
