### PR TITLE
Add ECB mode support to AES keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *~
 .metadata
+.idea
+**/*.iml

--- a/java/code/pom.xml
+++ b/java/code/pom.xml
@@ -121,8 +121,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
 	<version>2.3.2</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.5</source>
+          <target>1.5</target>
         </configuration>
       </plugin>
 

--- a/java/code/pom.xml
+++ b/java/code/pom.xml
@@ -6,7 +6,7 @@
   <artifactId>keyczar</artifactId>
 
   <name>Keyczar</name>
-  <version>0.71g</version>
+  <version>0.71g-sigfig</version>
   <url>http://www.keyczar.org</url>
 
   <description>

--- a/java/code/pom.xml
+++ b/java/code/pom.xml
@@ -121,8 +121,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
 	<version>2.3.2</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
 

--- a/java/code/src/org/keyczar/AesKey.java
+++ b/java/code/src/org/keyczar/AesKey.java
@@ -219,11 +219,10 @@ public class AesKey extends KeyczarKey {
     public void initDecrypt(ByteBuffer input) {
       // This will simply decrypt the first block, leaving the CBC Cipher
       // ready for the next block of input.
-      if (usesIv) {
-        byte[] iv = new byte[BLOCK_SIZE];
-        input.get(iv);
-        decryptingCipher.update(iv);
-      }
+
+      byte[] iv = new byte[usesIv ? BLOCK_SIZE : 0];
+      input.get(iv);
+      decryptingCipher.update(iv);
       ivRead = true;
     }
 
@@ -242,7 +241,7 @@ public class AesKey extends KeyczarKey {
     @Override
     public int updateDecrypt(ByteBuffer input, ByteBuffer output)
         throws KeyczarException {
-      if (ivRead && input.remaining() >= BLOCK_SIZE) {
+      if (usesIv && ivRead && input.remaining() >= BLOCK_SIZE) {
         // The next output block will be the IV preimage, which we'll discard
         byte[] temp = new byte[BLOCK_SIZE];
         input.get(temp);

--- a/java/code/src/org/keyczar/AesKey.java
+++ b/java/code/src/org/keyczar/AesKey.java
@@ -178,9 +178,18 @@ public class AesKey extends KeyczarKey {
       IvParameterSpec zeroIv = new IvParameterSpec(new byte[BLOCK_SIZE]);
       try {
         encryptingCipher = Cipher.getInstance(mode.getMode());
-        encryptingCipher.init(Cipher.ENCRYPT_MODE, aesKey, zeroIv);
+        if (mode.usesIv){
+          encryptingCipher.init(Cipher.ENCRYPT_MODE, aesKey, zeroIv);
+        } else {
+          encryptingCipher.init(Cipher.ENCRYPT_MODE, aesKey);
+        }
+
         decryptingCipher = Cipher.getInstance(mode.getMode());
-        decryptingCipher.init(Cipher.DECRYPT_MODE, aesKey, zeroIv);
+        if (mode.usesIv) {
+          decryptingCipher.init(Cipher.DECRYPT_MODE, aesKey, zeroIv);
+        } else {
+          decryptingCipher.init(Cipher.DECRYPT_MODE, aesKey);
+        }
         signStream = (SigningStream) hmacKey.getStream();
       } catch (GeneralSecurityException e) {
         throw new KeyczarException(e);

--- a/java/code/src/org/keyczar/DefaultKeyType.java
+++ b/java/code/src/org/keyczar/DefaultKeyType.java
@@ -16,6 +16,7 @@
 
 package org.keyczar;
 
+import org.keyczar.enums.CipherMode;
 import org.keyczar.enums.RsaPadding;
 import org.keyczar.exceptions.KeyczarException;
 import org.keyczar.exceptions.UnsupportedTypeException;
@@ -174,6 +175,16 @@ public enum DefaultKeyType implements KeyType {
     public HmacKey getHmacKey() throws KeyczarException {
       return HmacKey.generate(HMAC_SHA1.applyDefaultParameters(null));
     }
+
+    @Override
+    public CipherMode getAESMode() throws KeyczarException {
+      if (baseParameters instanceof AesKeyParameters){
+        return ((AesKeyParameters) baseParameters).getAESMode();
+      }
+      return CipherMode.CBC;
+    }
+
+
   }
 
   private final class DefaultingRsaKeyParameters extends DefaultingKeyParameters

--- a/java/code/src/org/keyczar/KeyMetadata.java
+++ b/java/code/src/org/keyczar/KeyMetadata.java
@@ -152,7 +152,7 @@ public class KeyMetadata {
     this.encrypted = encrypted;
   }
 
-  boolean isEncrypted() {
+  public boolean isEncrypted() {
     return encrypted;
   }
 
@@ -166,7 +166,7 @@ public class KeyMetadata {
     return versionMap.get(versionNumber);
   }
 
-  List<KeyVersion> getVersions() {
+  public List<KeyVersion> getVersions() {
     return versions;
   }
 

--- a/java/code/src/org/keyczar/KeyczarTool.java
+++ b/java/code/src/org/keyczar/KeyczarTool.java
@@ -121,6 +121,7 @@ public class KeyczarTool {
         final String passphraseFlag = flagMap.get(Flag.PASSPHRASE);
         final String pemFileFlag = flagMap.get(Flag.PEMFILE);
         final String versionFlag = flagMap.get(Flag.VERSION);
+        final String modeFlag = flagMap.get(Flag.MODE);
 
         switch (Command.getCommand(nonFlagArgs.get(0))) {
           case CREATE:

--- a/java/code/src/org/keyczar/KeyczarToolKeyParameters.java
+++ b/java/code/src/org/keyczar/KeyczarToolKeyParameters.java
@@ -1,5 +1,6 @@
 package org.keyczar;
 
+import org.keyczar.enums.CipherMode;
 import org.keyczar.enums.Flag;
 import org.keyczar.enums.RsaPadding;
 import org.keyczar.exceptions.KeyczarException;
@@ -55,4 +56,19 @@ public class KeyczarToolKeyParameters implements AesKeyParameters, RsaKeyParamet
   public HmacKey getHmacKey() throws KeyczarException {
     return HmacKey.generate(DefaultKeyType.HMAC_SHA1.applyDefaultParameters(null));
   }
+
+  @Override
+  public CipherMode getAESMode() throws KeyczarException {
+
+    if (flagMap.containsKey(Flag.MODE)) {
+      try {
+        return CipherMode.valueOf(flagMap.get(Flag.MODE).toUpperCase());
+      } catch (IllegalArgumentException e) {
+        throw new KeyczarException(Messages.getString("InvalidMode", flagMap.get(Flag.MODE)));
+      }
+    } else {
+      return CipherMode.CBC;
+    }
+  }
+
 }

--- a/java/code/src/org/keyczar/SignedSessionEncrypter.java
+++ b/java/code/src/org/keyczar/SignedSessionEncrypter.java
@@ -19,6 +19,7 @@ package org.keyczar;
 import static org.keyczar.util.Util.rand;
 
 import org.keyczar.annotations.Experimental;
+import org.keyczar.enums.CipherMode;
 import org.keyczar.exceptions.KeyczarException;
 import org.keyczar.keyparams.AesKeyParameters;
 import org.keyczar.util.Base64Coder;
@@ -88,6 +89,11 @@ public class SignedSessionEncrypter {
       @Override
       public HmacKey getHmacKey() throws KeyczarException {
         return HmacKey.generate(DefaultKeyType.HMAC_SHA1.applyDefaultParameters(null));
+      }
+
+      @Override
+      public CipherMode getAESMode() throws KeyczarException {
+        return CipherMode.CBC;
       }
     };
     SessionMaterial sessionMaterial = new SessionMaterial(buildSessionKey(params), buildNonce());

--- a/java/code/src/org/keyczar/enums/CipherMode.java
+++ b/java/code/src/org/keyczar/enums/CipherMode.java
@@ -29,7 +29,7 @@ package org.keyczar.enums;
 public enum CipherMode {
   CBC("AES/CBC/PKCS5Padding", true),
   CTR("AES/CTR/NoPadding", true),
-  ECB("AES/ECB/NoPadding", false),
+  ECB("AES/ECB/PKCS5Padding", false),
   DET_CBC("AES/CBC/PKCS5Padding",false);
 
   private String jceMode;

--- a/java/code/src/org/keyczar/enums/CipherMode.java
+++ b/java/code/src/org/keyczar/enums/CipherMode.java
@@ -27,15 +27,17 @@ package org.keyczar.enums;
  *
  */
 public enum CipherMode {
-  CBC("AES/CBC/PKCS5Padding"),
-  CTR("AES/CTR/NoPadding"),
-  ECB("AES/ECB/NoPadding"),
-  DET_CBC("AES/CBC/PKCS5Padding");
+  CBC("AES/CBC/PKCS5Padding", true),
+  CTR("AES/CTR/NoPadding", true),
+  ECB("AES/ECB/NoPadding", false),
+  DET_CBC("AES/CBC/PKCS5Padding",false);
 
   private String jceMode;
+  public final boolean usesIv;
 
-  private CipherMode(String s) {
+  private CipherMode(String s, final boolean usesIv) {
     jceMode = s;
+    this.usesIv = usesIv;
   }
 
   public String getMode() {

--- a/java/code/src/org/keyczar/enums/Flag.java
+++ b/java/code/src/org/keyczar/enums/Flag.java
@@ -35,7 +35,8 @@ public enum Flag {
   ASYMMETRIC("asymmetric"),
   CRYPTER("crypter"),
   PEMFILE("pemfile"),
-  PASSPHRASE("passphrase");
+  PASSPHRASE("passphrase"),
+  MODE("mode");
 
   private final String name;
 
@@ -76,6 +77,8 @@ public enum Flag {
       return PASSPHRASE;
     } else if (name.equalsIgnoreCase(PADDING.toString())) {
       return PADDING;
+    } else if (name.equalsIgnoreCase(MODE.toString())){
+      return MODE;
     }
     throw new IllegalArgumentException(
         Messages.getString("Flag.UnknownFlag", name));

--- a/java/code/src/org/keyczar/keyparams/AesKeyParameters.java
+++ b/java/code/src/org/keyczar/keyparams/AesKeyParameters.java
@@ -3,6 +3,7 @@
 package org.keyczar.keyparams;
 
 import org.keyczar.HmacKey;
+import org.keyczar.enums.CipherMode;
 import org.keyczar.exceptions.KeyczarException;
 
 /**
@@ -17,4 +18,7 @@ public interface AesKeyParameters extends KeyParameters {
    * @throws KeyczarException
    */
   HmacKey getHmacKey() throws KeyczarException;
+
+  CipherMode getAESMode() throws KeyczarException;
+
 }


### PR DESCRIPTION
We understand that ECB mode is generally considered less secure than CBC, but our application use case requires that we have consistent encrypted values, and we're only using this for data that's less than a single block.

It seems like keyczar had planned on adding support for other AES modes since the enums were there, but there were some hard coded assumptions that there would always be an IV. This patch removes those assumptions and allows ECB (and presumably CTR, though that's untested) encryption to work.
