### PR TITLE
Change the Java source version to 1.6

### DIFF
--- a/java/code/pom.xml
+++ b/java/code/pom.xml
@@ -121,7 +121,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
 	<version>2.3.2</version>
         <configuration>
-          <source>1.5</source>
+          <source>1.6</source>
           <target>1.5</target>
         </configuration>
       </plugin>


### PR DESCRIPTION
We are using 1.6 source, for example @Override on interface method
implementations.

Changing this means that the generated projects don't have errors when
opened in an IDE.
