### PR TITLE
fix hardcoded temp file paths in KeyczarToolTest

### DIFF
--- a/java/code/tests/org/keyczar/KeyczarToolTest.java
+++ b/java/code/tests/org/keyczar/KeyczarToolTest.java
@@ -16,6 +16,7 @@
 
 package org.keyczar;
 
+import java.io.File;
 import java.io.RandomAccessFile;
 
 import junit.framework.TestCase;
@@ -285,9 +286,8 @@ public class KeyczarToolTest extends TestCase {
     try {
       KeyczarTool.setReader(null); // use real reader
       String testKeyPath = "./testdata/aes";
-      // TODO(mtomczak): Choose a safer location for this scratch file.
-      String testOutputPath = "/tmp/keyczar_test_output";
-      String testOutputPath2 = "/tmp/keyczar_test_output_2";
+      String testOutputPath = File.createTempFile("keyczar_test", "output").toString();
+      String testOutputPath2 = File.createTempFile("keczar_test", "output_2").toString();
       String testMsg = "hello, world!";
       Crypter crypter = new Crypter(testKeyPath);
 


### PR DESCRIPTION
This does not work on systems where /tmp is not the temporary directory (such as Windows) or on systems that run multiple parallel builds
