### PR TITLE
Replace the Memoize decorator with property cache to avoid memory leak.

### DIFF
--- a/python/src/keyczar/keyczar.py
+++ b/python/src/keyczar/keyczar.py
@@ -291,7 +291,7 @@ class GenericKeyczar(Keyczar):
     if isinstance(writer, basestring):
       writer = writers.CreateWriter(writer)
       warnings.warn(
-        'Using a string as the writer is deprecated. Use writers.CreateWriter', 
+        'Using a string as the writer is deprecated. Use writers.CreateWriter',
         DeprecationWarning)
     self.metadata.encrypted = (encrypter is not None)
     writer.WriteMetadata(self.metadata)
@@ -352,7 +352,7 @@ class Encrypter(Keyczar):
     @type output_stream: 'file-like' object
 
     @param encoder: the encoding stream to use on the ciphertext stream.
-    Defaults to base64 encoding with no padding or line breaks. 
+    Defaults to base64 encoding with no padding or line breaks.
     Use None for raw bytes.
     @type encoder: 'file-like' object
 
@@ -547,7 +547,7 @@ class Crypter(Encrypter):
     @type output_stream: 'file-like' object
 
     @param decoder: the decoding stream to use on the incoming stream.
-    Defaults to base64 decoding with no padding or line breaks. 
+    Defaults to base64 decoding with no padding or line breaks.
     Use None for handling raw bytes.
     @type decoder: 'file-like' object
 
@@ -729,12 +729,14 @@ class _Session(object):
     return session
 
   @property
-  @util.Memoize
   def crypter(self):
     """
     Returns a Crypter which can be used to encrypt and decrypt data using the session key.
     """
-    return Crypter(readers.StaticKeyReader(self.__session_key, keyinfo.DECRYPT_AND_ENCRYPT))
+    if not hasattr(self, '_crypter'):
+        self._crypter = Crypter(readers.StaticKeyReader(
+            self.__session_key, keyinfo.DECRYPT_AND_ENCRYPT))
+    return self._crypter
 
   @property
   def nonce(self):

--- a/python/src/keyczar/util.py
+++ b/python/src/keyczar/util.py
@@ -579,7 +579,7 @@ class IncrementalBase64WSStreamWriter(codecs.StreamWriter, object):
 
   """
   def __init__(self, stream, errors='strict'):
-    """ 
+    """
     Creates an IncrementalBase64WSStreamWriter instance.
 
     @param stream: a file-like object open for writing (binary) data.
@@ -706,7 +706,7 @@ class IncrementalBase64WSStreamReader(codecs.StreamReader, object):
   """
 
   def __init__(self, stream, errors='strict'):
-    """ 
+    """
     Creates an IncrementalBase64WSStreamReader instance.
 
     @param stream: a file-like object open for reading (binary) data.
@@ -730,7 +730,7 @@ class IncrementalBase64WSStreamReader(codecs.StreamReader, object):
     self.decoder = BufferedIncrementalBase64WSDecoder(errors=errors)
 
   def read(self, size=-1, chars=-1, firstline=False):
-    """ 
+    """
     Decodes data from the input stream and returns the resulting object.
 
     @param chars: the number of characters to read from the stream. read() will
@@ -756,7 +756,7 @@ class IncrementalBase64WSStreamReader(codecs.StreamReader, object):
     end of the input data has been reached.
     @rtype: string
     """
-    
+
     # NOTE: this is a copy of the code from Python v2.7 codecs.py tweaked to
     # handle non-blocking streams i.e. those that return None to indicate no
     # data is available but is not at EOF - see read() in the Python I/O module
@@ -845,27 +845,6 @@ class IncrementalBase64WSStreamReader(codecs.StreamReader, object):
     """
     return self.decoder.decode(input)
 
-
-def Memoize(func):
-  """
-  General-purpose memoization decorator.  Handles functions with any number of arguments,
-  including keyword arguments.
-  """
-  memory = {}
-
-  @functools.wraps(func)
-  def memo(*args,**kwargs):
-    pickled_args = cPickle.dumps((args, sorted(kwargs.iteritems())))
-
-    if pickled_args not in memory:
-      memory[pickled_args] = func(*args,**kwargs)
-
-    return memory[pickled_args]
-
-  if memo.__doc__:
-    memo.__doc__ = "\n".join([memo.__doc__,"This function is memoized."])
-  return memo
-
 def ImportAll(pluginpath):
   """
   Simple plugin importer - imports from the specified subdirectory under the
@@ -883,7 +862,7 @@ def ImportAll(pluginpath):
 
 def ImportBackends():
   """
-  Simple backend plugin importer - imports from the 'backends' subdirectory 
+  Simple backend plugin importer - imports from the 'backends' subdirectory
   under the util.py directory and any directories in the environment variable
   'KEYCZAR_BACKEND_PATHS', which can contain >=1 paths joined using the o/s
   """
@@ -893,4 +872,3 @@ def ImportBackends():
   if xtra_paths:
     for path in xtra_paths.split(os.pathsep):
       ImportAll(path)
-


### PR DESCRIPTION
The existing util.Memoize has memory leaks.  The cache is shared across session objects.
