### PR TITLE
Explicitly close file.

### DIFF
--- a/python/src/keyczar/util.py
+++ b/python/src/keyczar/util.py
@@ -475,7 +475,8 @@ def ReadFile(loc):
   @raise KeyczarError: if unable to read from file because of IOError
   """
   try:
-    return open(loc).read()
+    with open(loc) as f:
+      return f.read()
   except IOError:
     raise errors.KeyczarError("Unable to read file %s." % loc)
 


### PR DESCRIPTION
PyPy's `-X track-resources` detects that this file is left open:

```
WARNING: unclosed file: <open file 'my_file', mode 'r' at 0x00000000373c19a0>
Created at (most recent call last):
[...]
  File "/root/.pyenv/versions/pypy2.7-5.9.0/site-packages/keyczar/keyczar.py", line 583, in Read
    return Signer(readers.CreateReader(location))
  File "/root/.pyenv/versions/pypy2.7-5.9.0/site-packages/keyczar/keyczar.py", line 66, in __init__
    reader.GetKey(version.version_number))
  File "/root/.pyenv/versions/pypy2.7-5.9.0/site-packages/keyczar/readers.py", line 107, in GetKey
    return util.ReadFile(os.path.join(self._location, str(version_number)))
  File "/root/.pyenv/versions/pypy2.7-5.9.0/site-packages/keyczar/util.py", line 478, in ReadFile
    return open(loc).read()
```